### PR TITLE
Fix: Sort all Tab Views by round name

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,8 @@
         <Copyright>Copyright 2011-$(CurrentYear) axuno gGmbH</Copyright>
         <RepositoryUrl>https://github.com/axuno/Volleyball-League</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <Version>6.1.2</Version>
-        <FileVersion>6.1.2</FileVersion>
+        <Version>6.1.3</Version>
+        <FileVersion>6.1.3</FileVersion>
         <AssemblyVersion>6.0.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>

--- a/League/LeagueStartup.cs
+++ b/League/LeagueStartup.cs
@@ -491,7 +491,7 @@ public static class LeagueStartup
         services.Configure<CookiePolicyOptions>(options =>
         {
             // determines whether user consent for non-essential cookies is needed for a given request.
-            options.CheckConsentNeeded = context => false;
+            options.CheckConsentNeeded = _ => false;
             options.MinimumSameSitePolicy = Microsoft.AspNetCore.Http.SameSiteMode.Lax;
             options.Secure = CookieSecurePolicy.SameAsRequest; // SameSite=None requires Secure
         });

--- a/League/Views/Match/Fixtures.cshtml
+++ b/League/Views/Match/Fixtures.cshtml
@@ -3,7 +3,7 @@
 @using TournamentManager.DAL.EntityClasses
 @using TournamentManager.DAL.TypedViewClasses
 @using TournamentManager.MultiTenancy
-@using League.MultiTenancy
+@using League.MultiTenancy @* don't remove *@
 @inject IViewLocalizer Localizer
 @inject ITenantContext TenantContext
 @inject TenantLink TenantLink
@@ -24,7 +24,8 @@
     }
 
     var activeRoundId = Model.ActiveRoundId ?? 0;
-    var rounds = Model.PlannedMatches.GroupBy(m => m.RoundName, (key, m) => new { RoundName = key, RoundId = m.First().RoundId, RoundDescription = m.First().RoundDescription, RoundTypeDescription = m.First().RoundTypeDescription }).ToList();
+    var rounds = Model.PlannedMatches.GroupBy(m => m.RoundName, (key, m) => new { RoundName = key, RoundId = m.First().RoundId, RoundDescription = m.First().RoundDescription, RoundTypeDescription = m.First().RoundTypeDescription })
+        .OrderBy(m => m.RoundName).ToList();
     var useRecentRoundCookie = !(Model.ActiveRoundId.HasValue && rounds.Any(r => r.RoundId == Model.ActiveRoundId));
     if (useRecentRoundCookie) { activeRoundId = rounds.FirstOrDefault()?.RoundId ?? 0; }
 

--- a/League/Views/Match/Results.cshtml
+++ b/League/Views/Match/Results.cshtml
@@ -23,7 +23,9 @@
 
     var activeRoundId = Model.ActiveRoundId ?? 0;
     var maxNumOfSets = Model.CompletedMatches.Max(m => m.Set.Count); // zero completed matches is already checked before
-    var rounds = Model.CompletedMatches.GroupBy(m => m.RoundName, (key, m) => new { RoundName = key, RoundId = m.First().RoundId, RoundDescription = m.First().RoundDescription, RoundTypeDescription = m.First().RoundTypeDescription }).ToList();
+    var rounds = Model.CompletedMatches
+        .GroupBy(m => m.RoundName, (key, m) => new { RoundName = key, RoundId = m.First().RoundId, RoundDescription = m.First().RoundDescription, RoundTypeDescription = m.First().RoundTypeDescription })
+        .OrderBy(m => m.RoundName).ToList();
     var useRecentRoundCookie = !(Model.ActiveRoundId.HasValue && rounds.Any(r => r.RoundId == Model.ActiveRoundId));
     if (useRecentRoundCookie) { activeRoundId = rounds.FirstOrDefault()?.RoundId ?? 0; }
     MatchEntity ToMatchEntity(CompletedMatchRow cmr)

--- a/League/Views/Ranking/AllTimeForTournament.cshtml
+++ b/League/Views/Ranking/AllTimeForTournament.cshtml
@@ -18,7 +18,10 @@
 
         return;
     }
-    var rounds = Model.RankingList.Where(rl => rl.TournamentId == Model.SelectedTournamentId).GroupBy(m => m.RoundName, (key, m) => new { RoundName = key, RoundId = m.First().RoundId, RoundDescription = m.First().RoundDescription, RoundTypeDescription = m.First().RoundTypeDescription }).ToList();
+    var rounds = Model.RankingList
+        .Where(rl => rl.TournamentId == Model.SelectedTournamentId)
+        .GroupBy(m => m.RoundName, (key, m) => new { RoundName = key, RoundId = m.First().RoundId, RoundDescription = m.First().RoundDescription, RoundTypeDescription = m.First().RoundTypeDescription })
+        .OrderBy(m => m.RoundName).ToList();
     var activeRoundId = rounds.First().RoundId;
 }
 <div class="mb-0 pb-1">

--- a/League/Views/Ranking/Table.cshtml
+++ b/League/Views/Ranking/Table.cshtml
@@ -21,7 +21,10 @@
     }
 
     var activeRoundId = Model.ActiveRoundId ?? 0;
-    var rounds = Model.RankingList.GroupBy(m => m.RoundName, (key, m) => new { RoundName = key, RoundId = m.First().RoundId, RoundDescription = m.First().RoundDescription, RoundTypeDescription = m.First().RoundTypeDescription }).ToList();
+    var rounds = Model.RankingList
+        .GroupBy(m => m.RoundName, (key, m) => new { RoundName = key, RoundId = m.First()
+            .RoundId, RoundDescription = m.First().RoundDescription, RoundTypeDescription = m.First().RoundTypeDescription })
+            .OrderBy(m => m.RoundName).ToList();
     var useRecentRoundCookie = !(Model.ActiveRoundId.HasValue && rounds.Any(r => r.RoundId == Model.ActiveRoundId));
     if (useRecentRoundCookie) { activeRoundId = rounds.FirstOrDefault()?.RoundId ?? 0; }
 }

--- a/League/Views/Team/_ChangeVenueModalPartial.cshtml
+++ b/League/Views/Team/_ChangeVenueModalPartial.cshtml
@@ -2,6 +2,7 @@
 @using Microsoft.AspNetCore.Mvc.Localization
 @using TournamentManager.MultiTenancy
 @using TournamentManager.DAL.TypedViewClasses
+@using League.MultiTenancy @* don't remove *@
 
 @inject IViewLocalizer Localizer
 @inject ITenantContext TenantContext


### PR DESCRIPTION
* Sort tabs by round name in Fixtures, Results, Table, AllTimeForTournament views
* Fix: Add missing 'using League.MultiTenancy' to _ChangeVenueModalPartial