### PR TITLE
Remove jQuery based client validation

### DIFF
--- a/League/Gruntfile.js
+++ b/League/Gruntfile.js
@@ -90,16 +90,6 @@ module.exports = function (grunt) {
                 dest: 'wwwroot/lib/jquery/jquery.min.js',
                 nonull: true
             },
-            jquery_validation: {
-                src: [
-                    'node_modules/jquery-validation/dist/jquery.validate.min.js',
-                    'node_modules/jquery-validation/dist/localization/methods_de.js',
-                    'node_modules/jquery-validation/dist/localization/messages_de.js',
-                    'node_modules/jquery-validation-unobtrusive/dist/jquery.validate.unobtrusive.min.js'
-                ],
-                dest: 'wwwroot/lib/jquery-validation/jquery-validation-all.min.js',
-                nonull: true
-            },
             bootstrap_js_all: {
                 src: ['node_modules/popper.js/dist/umd/popper.min.js',
                     'node_modules/popper.js/dist/umd/popper-utils.min.js',

--- a/League/LeagueStartup.cs
+++ b/League/LeagueStartup.cs
@@ -569,6 +569,7 @@ public static class LeagueStartup
                 options.ModelBinderProviders.Insert(0, new TimeSpanModelBinderProvider());
                 options.ModelBinderProviders.Insert(0, new DateTimeModelBinderProvider());
             })
+            .AddViewOptions(options => options.HtmlHelperOptions.ClientValidationEnabled = false)
             .AddControllersAsServices(); // will add controllers with ServiceLifetime.Transient
 
         #region *** Text Templating ***

--- a/League/Views/Account/CreateAccount.cshtml
+++ b/League/Views/Account/CreateAccount.cshtml
@@ -75,9 +75,6 @@
     </form>
 </div>
 @section Scripts {
-    @{
-        await Html.RenderPartialAsync(League.Views.ViewNames.Shared._ValidationScriptsPartial);
-    }
     <script type="text/javascript">
         $('#@Html.IdFor(m => m.Email)').focus();
         $('input').one('keypress', function() { $('#social-network').animate({ height: 0, opacity: 0 }, 'slow'); });

--- a/League/Views/Account/ExternalSignInConfirmation.cshtml
+++ b/League/Views/Account/ExternalSignInConfirmation.cshtml
@@ -66,6 +66,4 @@
         <button type="submit" class="btn btn-lg btn-primary col-10">@Localizer["Associate account"]</button>
     </div>
 </form>
-@section Scripts {
-    @{ await Html.RenderPartialAsync(League.Views.ViewNames.Shared._ValidationScriptsPartial); }
-}
+@section Scripts {}

--- a/League/Views/Account/ForgotPassword.cshtml
+++ b/League/Views/Account/ForgotPassword.cshtml
@@ -35,5 +35,4 @@
     <script type="text/javascript">
         $('#@Html.IdFor(m => m.EmailOrUsername)').focus();
     </script>
-    @{ await Html.RenderPartialAsync(League.Views.ViewNames.Shared._ValidationScriptsPartial); }
 }

--- a/League/Views/Account/Register.cshtml
+++ b/League/Views/Account/Register.cshtml
@@ -91,9 +91,6 @@
     </form>
 </div>
 @section Scripts {
-    @{
-        await Html.RenderPartialAsync(League.Views.ViewNames.Shared._ValidationScriptsPartial);
-    }
     <script type="text/javascript">
         $('#@Html.IdFor(m => m.ConfirmPassword)').attr("type", "password");
         $('#@Html.IdFor(m => m.Password)').attr("type", "password").focus();

--- a/League/Views/Account/ResetPassword.cshtml
+++ b/League/Views/Account/ResetPassword.cshtml
@@ -55,9 +55,6 @@
     </form>
 </div>
 @section Scripts {
-    @{
-        await Html.RenderPartialAsync(League.Views.ViewNames.Shared._ValidationScriptsPartial);
-    }
     <script type="text/javascript">
     $('#@Html.IdFor(m => m.Password)').attr("type", "password");
     $('#@Html.IdFor(m => m.ConfirmPassword)').attr("type", "password");

--- a/League/Views/Account/SignIn.cshtml
+++ b/League/Views/Account/SignIn.cshtml
@@ -88,8 +88,6 @@
     </section>
 </div>
 @section Scripts {
-    @{ await Html.RenderPartialAsync(League.Views.ViewNames.Shared._ValidationScriptsPartial); }
-    @* <partial name="_ValidationScriptsPartial"/> but name not resolved by R# *@
     <script type="text/javascript">
         // Show tab coming from e.g. url#social-network
         // $('.nav-tabs a[href="' + window.location.hash + '"]').tab('show');

--- a/League/Views/Contact/Index.cshtml
+++ b/League/Views/Contact/Index.cshtml
@@ -80,8 +80,4 @@
         </div>
     </form>
 </div>
-@section Scripts {
-    @{
-        await Html.RenderPartialAsync(League.Views.ViewNames.Shared._ValidationScriptsPartial);
-    }
-}
+@section Scripts {}

--- a/League/Views/Manage/_ChangeEmailModalPartial.cshtml
+++ b/League/Views/Manage/_ChangeEmailModalPartial.cshtml
@@ -31,4 +31,3 @@
         <button site-ajax-submit class="btn btn-primary">@Localizer["Save"].Value</button>
     </modal-footer>
 </modal>
-@{ await Html.RenderPartialAsync(League.Views.ViewNames.Shared._ValidationScriptsPartial); /* register the modal form for validation */ }

--- a/League/Views/Manage/_ChangePasswordModalPartial.cshtml
+++ b/League/Views/Manage/_ChangePasswordModalPartial.cshtml
@@ -50,4 +50,3 @@
         <button site-ajax-submit class="btn btn-primary">@Localizer["Save"].Value</button>
     </modal-footer>
 </modal>
-@{ await Html.RenderPartialAsync(League.Views.ViewNames.Shared._ValidationScriptsPartial); /* register the modal form for validation */ }

--- a/League/Views/Manage/_ChangeUsernameModalPartial.cshtml
+++ b/League/Views/Manage/_ChangeUsernameModalPartial.cshtml
@@ -7,7 +7,6 @@
 @inject ITenantContext TenantContext
 @inject IUserValidator<ApplicationUser> userValidator
 @{ var UserValidator = (LeagueUserValidator<ApplicationUser>)this.userValidator;
-    ViewContext.ClientValidationEnabled = false;
     var tenantUrlSegment = TenantContext.SiteContext.UrlSegmentValue;}
 @model ChangeUsernameViewModel
 @{ var allowedUsernameCharacters = Axuno.Tools.StringFormatter.GroupedValidCharacters(UserManager.Options.User.AllowedUserNameCharacters);}
@@ -32,4 +31,3 @@
         <button site-ajax-submit class="btn btn-primary">@Localizer["Save"]</button>
     </modal-footer>
 </modal>
-@{ if (ViewContext.ClientValidationEnabled) { await Html.RenderPartialAsync(League.Views.ViewNames.Shared._ValidationScriptsPartial); } /* register the modal form for validation */ }

--- a/League/Views/Manage/_EditEmail2ModalPartial.cshtml
+++ b/League/Views/Manage/_EditEmail2ModalPartial.cshtml
@@ -5,7 +5,6 @@
 @inject ITenantContext TenantContext
 @model EditEmail2ViewModel
 @{ const string BtnRemove = "btn-remove";
-    ViewContext.ClientValidationEnabled = true; 
     var tenantUrlSegment = TenantContext.SiteContext.UrlSegmentValue;
 }
 <!-- Modal -->
@@ -32,7 +31,6 @@
         <script type="text/javascript">
             $('#@BtnRemove').on('click', function() { $('#@nameof(Model.Email2)').val(''); });
         </script>
-        @{ if (ViewContext.ClientValidationEnabled) { await Html.RenderPartialAsync(League.Views.ViewNames.Shared._ValidationScriptsPartial); } /* register the modal form for validation */ }
     </modal-body>
     <modal-footer show-dismiss="true" dismiss-text="@Localizer["Cancel"].Value">
         <button site-ajax-submit id="@BtnRemove" class="btn btn-info" type="button">@Localizer["Remove"].Value</button>

--- a/League/Views/Manage/_EditPersonalDetailsModalPartial.cshtml
+++ b/League/Views/Manage/_EditPersonalDetailsModalPartial.cshtml
@@ -5,7 +5,6 @@
 @inject IViewLocalizer Localizer
 @inject ITenantContext TenantContext
 @{
-    ViewContext.ClientValidationEnabled = true;
     var tenantUrlSegment = TenantContext.SiteContext.UrlSegmentValue;
     List<SelectListItem> GenderList()
     {
@@ -53,4 +52,4 @@
         <button site-ajax-submit class="btn btn-primary">@Localizer["Save"].Value</button>
     </modal-footer>
 </modal>
-@{ if (ViewContext.ClientValidationEnabled) { await Html.RenderPartialAsync(League.Views.ViewNames.Shared._ValidationScriptsPartial); } /* register the modal form for validation */ }
+

--- a/League/Views/Manage/_EditPhone2ModalPartial.cshtml
+++ b/League/Views/Manage/_EditPhone2ModalPartial.cshtml
@@ -5,7 +5,6 @@
 @inject ITenantContext TenantContext
 @model EditPhone2ViewModel
 @{ const string BtnRemove = "btn-remove";
-    ViewContext.ClientValidationEnabled = true;
     var tenantUrlSegment = TenantContext.SiteContext.UrlSegmentValue;
 }
 <!-- Modal -->
@@ -29,7 +28,6 @@
         <script type="text/javascript">
             $('#@BtnRemove').on('click', function () { $('#@nameof(Model.PhoneNumber2)').val(''); });
         </script>
-        @{ if (ViewContext.ClientValidationEnabled) { await Html.RenderPartialAsync(League.Views.ViewNames.Shared._ValidationScriptsPartial); } /* register the modal form for validation */ }
     </modal-body>
     <modal-footer show-dismiss="true" dismiss-text="@Localizer["Cancel"].Value">
         <button site-ajax-submit id="@BtnRemove" class="btn btn-info" type="button">@Localizer["Remove"].Value</button>

--- a/League/Views/Manage/_EditPhoneModalPartial.cshtml
+++ b/League/Views/Manage/_EditPhoneModalPartial.cshtml
@@ -6,7 +6,6 @@
 @model EditPhoneViewModel
 @{
     const string BtnRemove = "btn-remove";
-    ViewContext.ClientValidationEnabled = true;
     var tenantUrlSegment = TenantContext.SiteContext.UrlSegmentValue;
 }
 <!-- Modal -->
@@ -30,7 +29,6 @@
         <script type="text/javascript">
             $('#@BtnRemove').on('click', function() { $('#@nameof(Model.PhoneNumber)').val(''); });
         </script>
-        @{ if (ViewContext.ClientValidationEnabled) { await Html.RenderPartialAsync(League.Views.ViewNames.Shared._ValidationScriptsPartial); } /* register the modal form for validation */ }
     </modal-body>
     <modal-footer show-dismiss="true" dismiss-text="@Localizer["Cancel"].Value">
         <button site-ajax-submit id="@BtnRemove" class="btn btn-info" type="button">@Localizer["Remove"].Value</button>

--- a/League/Views/Manage/_SetPasswordModalPartial.cshtml
+++ b/League/Views/Manage/_SetPasswordModalPartial.cshtml
@@ -8,7 +8,6 @@
 @{
     ViewData["Title"] = Localizer["Set Password"].Value;
     var tenantUrlSegment = TenantContext.SiteContext.UrlSegmentValue;
-    ViewContext.ClientValidationEnabled = true;
 }
 @model SetPasswordViewModel
 <!-- Modal -->
@@ -39,4 +38,3 @@
         <button site-ajax-submit class="btn btn-primary">@Localizer["Save"]</button>
     </modal-footer>
 </modal>
-@{ if (ViewContext.ClientValidationEnabled) { await Html.RenderPartialAsync(League.Views.ViewNames.Shared._ValidationScriptsPartial); } /* register the modal form for validation */ }

--- a/League/Views/Match/EditFixture.cshtml
+++ b/League/Views/Match/EditFixture.cshtml
@@ -5,7 +5,6 @@
 @using TournamentManager.MultiTenancy
 @inject ITenantContext TenantContext
 @inject IViewLocalizer Localizer
-@{ ViewContext.ClientValidationEnabled = false;}  @* We rely on datepicker and server side validation *@
 @model League.Models.MatchViewModels.EditFixtureViewModel
 @{
     if (Model.Tournament == null || Model.PlannedMatch == null) return;
@@ -139,10 +138,6 @@
     <script type="text/javascript" src="~/lib/Moment/moment.min.js"></script>
     <script type="text/javascript" src="~/lib/tempusdominus-bootstrap-4/tempusdominus-bootstrap-4.min.js"></script>
     <partial name="@nameof(League.Views.ViewNames.Shared._DateTimePickerScriptPartial)" />
-    @if (ViewContext.ClientValidationEnabled)
-    {
-        <partial name="@nameof(League.Views.ViewNames.Shared._ValidationScriptsPartial)" />
-    }
     <script type="text/javascript">
         $(document).ready(function () {
             // don't use attribute 'autofocus' with datetimepicker - this will focus before initialization

--- a/League/Views/Match/EnterResult.cshtml
+++ b/League/Views/Match/EnterResult.cshtml
@@ -6,7 +6,6 @@
 @inject RegionInfo RegionInfo
 @inject IViewLocalizer Localizer
 @inject ITenantContext TenantContext
-@{ ViewContext.ClientValidationEnabled = false;}  @* We rely on datepicker and server side validation *@
 @model League.Models.MatchViewModels.EnterResultViewModel
 @{
     ViewData["Title"] = Localizer["Enter Match Result"].Value + " - " + Model.Tournament?.Name;
@@ -158,10 +157,6 @@
     <script type="text/javascript" src="~/lib/Moment/moment.min.js"></script>
     <script type="text/javascript" src="~/lib/tempusdominus-bootstrap-4/tempusdominus-bootstrap-4.min.js"></script>
     <partial name="@nameof(League.Views.ViewNames.Shared._DateTimePickerScriptPartial)" />
-    @if (ViewContext.ClientValidationEnabled)
-    {
-        <partial name="@nameof(League.Views.ViewNames.Shared._ValidationScriptsPartial)" />
-    }
     <script type="text/javascript">
     $(document).ready(function() {
         // don't use attribute 'autofocus' with datetimepicker - this will focus before initialization

--- a/League/Views/Match/EnterResultNotAllowed.cshtml
+++ b/League/Views/Match/EnterResultNotAllowed.cshtml
@@ -1,6 +1,5 @@
 ﻿@using Microsoft.AspNetCore.Mvc.Localization
 @inject IViewLocalizer Localizer
-@{ ViewContext.ClientValidationEnabled = false;}  @* We rely on datepicker and server side validation *@
 @model (TournamentManager.DAL.EntityClasses.TournamentEntity Tournament, string Message)
 @{
     ViewData["Title"] = Localizer["Enter Match Result"].Value + " - " + Model.Tournament.Name;

--- a/League/Views/Role/_AddMemberModalPartial.cshtml
+++ b/League/Views/Role/_AddMemberModalPartial.cshtml
@@ -5,7 +5,6 @@
 @model League.Models.RoleViewModels.RoleAddModel
 @{
     var selectableRoleNames = new[] { League.Identity.Constants.ClaimType.PlaysInTeam, League.Identity.Constants.ClaimType.ManagesTeam };
-    ViewContext.ClientValidationEnabled = false;
     var tenantUrlSegment = TenantContext.SiteContext.UrlSegmentValue;
 }
 <!-- Modal -->
@@ -39,11 +38,5 @@
     </modal-body>
     <modal-footer show-dismiss="true" dismiss-text="@_AddMemberModalPartial.Cancel">
         <button site-ajax-submit class="btn btn-primary">@_AddMemberModalPartial.Add</button>
-        @{ if (ViewContext.ClientValidationEnabled)
-            {
-                /* register the modal form for validation */
-                <partial name="@nameof(League.Views.ViewNames.Shared._ValidationScriptsPartial)" />
-            }
-        }
     </modal-footer>
 </modal>

--- a/League/Views/Role/_RemoveMemberModalPartial.cshtml
+++ b/League/Views/Role/_RemoveMemberModalPartial.cshtml
@@ -5,7 +5,7 @@
 @inject IViewLocalizer Localizer
 @inject ITenantContext TenantContext
 @model League.Models.RoleViewModels.RoleRemoveModel
-@{ ViewContext.ClientValidationEnabled = false; var tenantUrlSegment = TenantContext.SiteContext.UrlSegmentValue;}
+@{ var tenantUrlSegment = TenantContext.SiteContext.UrlSegmentValue;}
 <!-- Modal -->
 <modal id="edit-team" title="@_RemoveMemberModalPartial.Remove_team_member" dialog-class="modal-md" tabindex="-1">
     <modal-body>

--- a/League/Views/Shared/Components/TeamEditor/Default.cshtml
+++ b/League/Views/Shared/Components/TeamEditor/Default.cshtml
@@ -1,7 +1,6 @@
 ﻿@using System.Globalization
 @using Microsoft.AspNetCore.Mvc.Localization
 @{ Layout = null; 
-ViewContext.ClientValidationEnabled = false;  @* We rely on datepicker and server side validation *@
 ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = Model.HtmlFieldPrefix;
 }
 @inject IViewLocalizer Localizer

--- a/League/Views/Shared/Components/VenueEditor/Default.cshtml
+++ b/League/Views/Shared/Components/VenueEditor/Default.cshtml
@@ -5,7 +5,6 @@
 @model League.Components.VenueEditorComponentModel
 @{
     Layout = null;
-    ViewContext.ClientValidationEnabled = false; @* We rely server side validation *@
     ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = Model.HtmlFieldPrefix;
 }
 <div class="row">

--- a/League/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/League/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -1,1 +1,0 @@
-﻿    <script src="~/lib/jquery-validation/jquery-validation-all.min.js"></script>    

--- a/League/Views/Team/_EditTeamModalPartial.cshtml
+++ b/League/Views/Team/_EditTeamModalPartial.cshtml
@@ -5,7 +5,7 @@
 @inject IViewLocalizer Localizer
 @inject ITenantContext TenantContext
 @model League.Models.TeamViewModels.TeamEditModel
-@{ ViewContext.ClientValidationEnabled = false; var tenantUrlSegment = TenantContext.SiteContext.UrlSegmentValue;}
+@{ var tenantUrlSegment = TenantContext.SiteContext.UrlSegmentValue;}
 <!-- Modal -->
 <modal id="edit-team" title="@Localizer["Edit team"].Value" dialog-class="modal-xl" tabindex="-1">
     <modal-body>
@@ -31,12 +31,6 @@
     </modal-body>
     <modal-footer show-dismiss="true" dismiss-text="@Localizer["Cancel"].Value">
         <button site-ajax-submit class="btn btn-primary">@Localizer["Save"]</button>
-        @{ if (ViewContext.ClientValidationEnabled)
-            {
-                /* register the modal form for validation */
-                <partial name="@nameof(League.Views.ViewNames.Shared._ValidationScriptsPartial)" />
-            }
-        }
     </modal-footer>
 </modal>
 

--- a/League/Views/TeamApplication/EditVenue.cshtml
+++ b/League/Views/TeamApplication/EditVenue.cshtml
@@ -6,8 +6,7 @@
 @inject IViewLocalizer Localizer
 @inject ITenantContext TenantContext
 @model League.Models.VenueViewModels.VenueEditModel
-@{ ViewContext.ClientValidationEnabled = false;
-    ViewData["Title"] = Localizer["Team Registration"].Value + " - " + ViewData["TournamentName"];
+@{  ViewData["Title"] = Localizer["Team Registration"].Value + " - " + ViewData["TournamentName"];
     var tenantUrlSegment = TenantContext.SiteContext.UrlSegmentValue;
 }
 <div class="mb-0 pb-1">

--- a/League/Views/Venue/EditVenue.cshtml
+++ b/League/Views/Venue/EditVenue.cshtml
@@ -6,8 +6,7 @@
 @inject IViewLocalizer Localizer
 @inject ITenantContext TenantContext
 @model League.Models.VenueViewModels.VenueEditModel
-@{ ViewContext.ClientValidationEnabled = false;
-    ViewData["Title"] = (Model.Venue.IsNew ? Localizer["Create venue"].Value : Localizer["Edit venue"].Value);
+@{  ViewData["Title"] = (Model.Venue.IsNew ? Localizer["Create venue"].Value : Localizer["Edit venue"].Value);
     var tenantUrlSegment = TenantContext.SiteContext.UrlSegmentValue;
 }
 <div class="mb-0 pb-1">

--- a/League/Views/ViewNames.cs
+++ b/League/Views/ViewNames.cs
@@ -5,154 +5,153 @@
  */
  #pragma warning disable CS1591
 
-namespace League.Views;
-
-public class ViewNames
+namespace League.Views
 {
-    public static class Account
+    public class ViewNames
     {
-        public const string ConfirmEmailError = "ConfirmEmailError";
-        public const string CreateAccount = "CreateAccount";
-        public const string ExternalSignInConfirmation = "ExternalSignInConfirmation";
-        public const string ExternalSignInFailure = "ExternalSignInFailure";
-        public const string ForgotPassword = "ForgotPassword";
-        public const string ForgotPasswordConfirmation = "ForgotPasswordConfirmation";
-        public const string PleaseConfirmEmail = "PleaseConfirmEmail";
-        public const string Register = "Register";
-        public const string ResetPassword = "ResetPassword";
-        public const string ResetPasswordConfirmation = "ResetPasswordConfirmation";
-        public const string SignIn = "SignIn";
-        public const string SignInRejected = "SignInRejected";
-        public const string SignInRejectedEmailNotConfirmed = "SignInRejectedEmailNotConfirmed";
-    }
-    public static class Contact
-    {
-        public const string ContactConfirmation = "ContactConfirmation";
-        public const string Index = "Index";
-    }
-    public static class Error
-    {
-        public const string AccessDenied = "AccessDenied";
-        public const string Index = "Index";
-    }
-    public static class Home
-    {
-        public const string AboutLeague = "AboutLeague";
-        public const string AboutLeaguede = "AboutLeague.de";
-        public const string LegalDisclosure = "LegalDisclosure";
-        public const string LegalDisclosurede = "LegalDisclosure.de";
-        public const string Overview = "Overview";
-        public const string PictureCredits = "PictureCredits";
-        public const string Privacy = "Privacy";
-        public const string Privacyde = "Privacy.de";
-        public const string Welcome = "Welcome";
-    }
-    public static class Manage
-    {
-        public const string Index = "Index";
-        public const string _ChangeEmailModalPartial = "_ChangeEmailModalPartial";
-        public const string _ChangePasswordModalPartial = "_ChangePasswordModalPartial";
-        public const string _ChangeUsernameModalPartial = "_ChangeUsernameModalPartial";
-        public const string _DeleteAccountModalPartial = "_DeleteAccountModalPartial";
-        public const string _EditEmail2ModalPartial = "_EditEmail2ModalPartial";
-        public const string _EditPersonalDetailsModalPartial = "_EditPersonalDetailsModalPartial";
-        public const string _EditPhone2ModalPartial = "_EditPhone2ModalPartial";
-        public const string _EditPhoneModalPartial = "_EditPhoneModalPartial";
-        public const string _IndexMessagesPartial = "_IndexMessagesPartial";
-        public const string _ManageLoginsModalPartial = "_ManageLoginsModalPartial";
-        public const string _SetPasswordModalPartial = "_SetPasswordModalPartial";
-    }
-    public static class Map
-    {
-        public const string Index = "Index";
-    }
-    public static class Match
-    {
-        public const string EditFixture = "EditFixture";
-        public const string EnterResult = "EnterResult";
-        public const string EnterResultNotAllowed = "EnterResultNotAllowed";
-        public const string Fixtures = "Fixtures";
-        public const string ReportSheet = "ReportSheet";
-        public const string Results = "Results";
-        public const string _FixtureMessagesPartial = "_FixtureMessagesPartial";
-        public const string _ResultMessagesPartial = "_ResultMessagesPartial";
-    }
-    public static class Ranking
-    {
-        public const string AllTimeForTeam = "AllTimeForTeam";
-        public const string AllTimeForTournament = "AllTimeForTournament";
-        public const string Table = "Table";
-    }
-    public static class Role
-    {
-        public const string _AddMemberModalPartial = "_AddMemberModalPartial";
-        public const string _RemoveMemberModalPartial = "_RemoveMemberModalPartial";
-    }
-    public static class Shared
-    {
-        public const string NavigationNodeChildDropdownPartial = "NavigationNodeChildDropdownPartial";
-        public const string _DateTimePickerScriptPartial = "_DateTimePickerScriptPartial";
-        public const string _FavIcons = "_FavIcons";
-        public const string _GoogleAnalyticsScriptsPartial = "_GoogleAnalyticsScriptsPartial";
-        public const string _LanguagePartial = "_LanguagePartial";
-        public const string _Layout = "_Layout";
-        public const string _passwordRules = "_passwordRules";
-        public const string _ValidationScriptsPartial = "_ValidationScriptsPartial";
-        public static class Components
+        public static class Account
         {
-            public static class MainNavigation
+            public const string ConfirmEmailError = "ConfirmEmailError";
+            public const string CreateAccount = "CreateAccount";
+            public const string ExternalSignInConfirmation = "ExternalSignInConfirmation";
+            public const string ExternalSignInFailure = "ExternalSignInFailure";
+            public const string ForgotPassword = "ForgotPassword";
+            public const string ForgotPasswordConfirmation = "ForgotPasswordConfirmation";
+            public const string PleaseConfirmEmail = "PleaseConfirmEmail";
+            public const string Register = "Register";
+            public const string ResetPassword = "ResetPassword";
+            public const string ResetPasswordConfirmation = "ResetPasswordConfirmation";
+            public const string SignIn = "SignIn";
+            public const string SignInRejected = "SignInRejected";
+            public const string SignInRejectedEmailNotConfirmed = "SignInRejectedEmailNotConfirmed";
+        }
+        public static class Contact
+        {
+            public const string ContactConfirmation = "ContactConfirmation";
+            public const string Index = "Index";
+        }
+        public static class Error
+        {
+            public const string AccessDenied = "AccessDenied";
+            public const string Index = "Index";
+        }
+        public static class Home
+        {
+            public const string AboutLeague = "AboutLeague";
+            public const string AboutLeaguede = "AboutLeague.de";
+            public const string LegalDisclosure = "LegalDisclosure";
+            public const string LegalDisclosurede = "LegalDisclosure.de";
+            public const string Overview = "Overview";
+            public const string PictureCredits = "PictureCredits";
+            public const string Privacy = "Privacy";
+            public const string Privacyde = "Privacy.de";
+            public const string Welcome = "Welcome";
+        }
+        public static class Manage
+        {
+            public const string Index = "Index";
+            public const string _ChangeEmailModalPartial = "_ChangeEmailModalPartial";
+            public const string _ChangePasswordModalPartial = "_ChangePasswordModalPartial";
+            public const string _ChangeUsernameModalPartial = "_ChangeUsernameModalPartial";
+            public const string _DeleteAccountModalPartial = "_DeleteAccountModalPartial";
+            public const string _EditEmail2ModalPartial = "_EditEmail2ModalPartial";
+            public const string _EditPersonalDetailsModalPartial = "_EditPersonalDetailsModalPartial";
+            public const string _EditPhone2ModalPartial = "_EditPhone2ModalPartial";
+            public const string _EditPhoneModalPartial = "_EditPhoneModalPartial";
+            public const string _IndexMessagesPartial = "_IndexMessagesPartial";
+            public const string _ManageLoginsModalPartial = "_ManageLoginsModalPartial";
+            public const string _SetPasswordModalPartial = "_SetPasswordModalPartial";
+        }
+        public static class Map
+        {
+            public const string Index = "Index";
+        }
+        public static class Match
+        {
+            public const string EditFixture = "EditFixture";
+            public const string EnterResult = "EnterResult";
+            public const string EnterResultNotAllowed = "EnterResultNotAllowed";
+            public const string Fixtures = "Fixtures";
+            public const string ReportSheet = "ReportSheet";
+            public const string Results = "Results";
+            public const string _FixtureMessagesPartial = "_FixtureMessagesPartial";
+            public const string _ResultMessagesPartial = "_ResultMessagesPartial";
+        }
+        public static class Ranking
+        {
+            public const string AllTimeForTeam = "AllTimeForTeam";
+            public const string AllTimeForTournament = "AllTimeForTournament";
+            public const string Table = "Table";
+        }
+        public static class Role
+        {
+            public const string _AddMemberModalPartial = "_AddMemberModalPartial";
+            public const string _RemoveMemberModalPartial = "_RemoveMemberModalPartial";
+        }
+        public static class Shared
+        {
+            public const string NavigationNodeChildDropdownPartial = "NavigationNodeChildDropdownPartial";
+            public const string _DateTimePickerScriptPartial = "_DateTimePickerScriptPartial";
+            public const string _FavIcons = "_FavIcons";
+            public const string _GoogleAnalyticsScriptsPartial = "_GoogleAnalyticsScriptsPartial";
+            public const string _LanguagePartial = "_LanguagePartial";
+            public const string _Layout = "_Layout";
+            public const string _passwordRules = "_passwordRules";
+            public static class Components
             {
-                public const string Default = "Default";
-            }
-            public static class RoundSelector
-            {
-                public const string Default = "Default";
-            }
-            public static class TeamEditor
-            {
-                public const string Default = "Default";
-            }
-            public static class VenueEditor
-            {
-                public const string Default = "Default";
-            }
-            public static class VenueSelector
-            {
-                public const string Default = "Default";
+                public static class MainNavigation
+                {
+                    public const string Default = "Default";
+                }
+                public static class RoundSelector
+                {
+                    public const string Default = "Default";
+                }
+                public static class TeamEditor
+                {
+                    public const string Default = "Default";
+                }
+                public static class VenueEditor
+                {
+                    public const string Default = "Default";
+                }
+                public static class VenueSelector
+                {
+                    public const string Default = "Default";
+                }
             }
         }
-    }
-    public static class Team
-    {
-        public const string List = "List";
-        public const string MyTeam = "MyTeam";
-        public const string MyTeamNotFound = "MyTeamNotFound";
-        public const string Single = "Single";
-        public const string _ChangeVenueModalPartial = "_ChangeVenueModalPartial";
-        public const string _EditTeamModalPartial = "_EditTeamModalPartial";
-        public const string _MyTeamMessagesPartial = "_MyTeamMessagesPartial";
-        public const string _SelectVenueModalPartial = "_SelectVenueModalPartial";
-    }
-    public static class TeamApplication
-    {
-        public const string Confirm = "Confirm";
-        public const string EditTeam = "EditTeam";
-        public const string EditVenue = "EditVenue";
-        public const string List = "List";
-        public const string SelectTeam = "SelectTeam";
-        public const string SelectVenue = "SelectVenue";
-        public const string Start = "Start";
-        public const string Startde = "Start.de";
-        public const string _TeamApplicationMessagesPartial = "_TeamApplicationMessagesPartial";
-    }
-    public static class Upload
-    {
-        public const string TeamPhoto = "TeamPhoto";
-    }
-    public static class Venue
-    {
-        public const string EditVenue = "EditVenue";
-    }
+        public static class Team
+        {
+            public const string List = "List";
+            public const string MyTeam = "MyTeam";
+            public const string MyTeamNotFound = "MyTeamNotFound";
+            public const string Single = "Single";
+            public const string _ChangeVenueModalPartial = "_ChangeVenueModalPartial";
+            public const string _EditTeamModalPartial = "_EditTeamModalPartial";
+            public const string _MyTeamMessagesPartial = "_MyTeamMessagesPartial";
+            public const string _SelectVenueModalPartial = "_SelectVenueModalPartial";
+        }
+        public static class TeamApplication
+        {
+            public const string Confirm = "Confirm";
+            public const string EditTeam = "EditTeam";
+            public const string EditVenue = "EditVenue";
+            public const string List = "List";
+            public const string SelectTeam = "SelectTeam";
+            public const string SelectVenue = "SelectVenue";
+            public const string Start = "Start";
+            public const string Startde = "Start.de";
+            public const string _TeamApplicationMessagesPartial = "_TeamApplicationMessagesPartial";
+        }
+        public static class Upload
+        {
+            public const string TeamPhoto = "TeamPhoto";
+        }
+        public static class Venue
+        {
+            public const string EditVenue = "EditVenue";
+        }
     public static class Area
     {
         public static class Admin
@@ -172,5 +171,6 @@ public class ViewNames
                 public const string ShowClaims = "ShowClaims";
             }
         }
+    }
     }
 }

--- a/League/package-lock.json
+++ b/League/package-lock.json
@@ -22,8 +22,6 @@
         "grunt-postcss": "0.9.0",
         "grunt-sass": "3.1.0",
         "jquery": "3.5.1",
-        "jquery-validation": "1.19.5",
-        "jquery-validation-unobtrusive": "3.2.12",
         "js-cookie": "2.2.1",
         "jsnlog": "2.30.0",
         "moment": "2.29.4",
@@ -1191,9 +1189,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.402",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.402.tgz",
-      "integrity": "sha512-gWYvJSkohOiBE6ecVYXkrDgNaUjo47QEKK0kQzmWyhkH+yoYiG44bwuicTGNSIQRG3WDMsWVZJLRnJnLNkbWvA==",
+      "version": "1.4.407",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.407.tgz",
+      "integrity": "sha512-5smEvFSFYMv90tICOzRVP7Opp98DAC4KW7RRipg3BuNpGbbV3N+x24Zh3sbLb1T5haGtOSy/hrBfXsWnIM9aCg==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -2930,25 +2928,6 @@
       "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
       "dev": true
     },
-    "node_modules/jquery-validation": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.19.5.tgz",
-      "integrity": "sha512-X2SmnPq1mRiDecVYL8edWx+yTBZDyC8ohWXFhXdtqFHgU9Wd4KHkvcbCoIZ0JaSaumzS8s2gXSkP8F7ivg/8ZQ==",
-      "dev": true,
-      "peerDependencies": {
-        "jquery": "^1.7 || ^2.0 || ^3.1"
-      }
-    },
-    "node_modules/jquery-validation-unobtrusive": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/jquery-validation-unobtrusive/-/jquery-validation-unobtrusive-3.2.12.tgz",
-      "integrity": "sha512-kPixGhVcuat7vZXngGFfSIksy4VlzZcHyRgnBIZdsfVneCU+D5sITC8T8dD/9c9K/Q+qkMlgp7ufJHz93nKSuQ==",
-      "dev": true,
-      "dependencies": {
-        "jquery": "^3.5.1",
-        "jquery-validation": ">=1.16"
-      }
-    },
     "node_modules/js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
@@ -3671,9 +3650,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.11.tgz",
-      "integrity": "sha512-+M0PwXeU80kRohZ3aT4J/OnR+l9/KD2nVLNNoRgFtnf+umQVFdGBAO2N8+nCnEi0xlh/Wk3zOGC+vNNx+uM79Q==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
+      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
       "dev": true
     },
     "node_modules/node-sass": {
@@ -7086,9 +7065,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.402",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.402.tgz",
-      "integrity": "sha512-gWYvJSkohOiBE6ecVYXkrDgNaUjo47QEKK0kQzmWyhkH+yoYiG44bwuicTGNSIQRG3WDMsWVZJLRnJnLNkbWvA==",
+      "version": "1.4.407",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.407.tgz",
+      "integrity": "sha512-5smEvFSFYMv90tICOzRVP7Opp98DAC4KW7RRipg3BuNpGbbV3N+x24Zh3sbLb1T5haGtOSy/hrBfXsWnIM9aCg==",
       "dev": true
     },
     "emoji-regex": {
@@ -8414,23 +8393,6 @@
       "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
       "dev": true
     },
-    "jquery-validation": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.19.5.tgz",
-      "integrity": "sha512-X2SmnPq1mRiDecVYL8edWx+yTBZDyC8ohWXFhXdtqFHgU9Wd4KHkvcbCoIZ0JaSaumzS8s2gXSkP8F7ivg/8ZQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "jquery-validation-unobtrusive": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/jquery-validation-unobtrusive/-/jquery-validation-unobtrusive-3.2.12.tgz",
-      "integrity": "sha512-kPixGhVcuat7vZXngGFfSIksy4VlzZcHyRgnBIZdsfVneCU+D5sITC8T8dD/9c9K/Q+qkMlgp7ufJHz93nKSuQ==",
-      "dev": true,
-      "requires": {
-        "jquery": "^3.5.1",
-        "jquery-validation": ">=1.16"
-      }
-    },
     "js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
@@ -9007,9 +8969,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.11.tgz",
-      "integrity": "sha512-+M0PwXeU80kRohZ3aT4J/OnR+l9/KD2nVLNNoRgFtnf+umQVFdGBAO2N8+nCnEi0xlh/Wk3zOGC+vNNx+uM79Q==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
+      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
       "dev": true
     },
     "node-sass": {

--- a/League/package.json
+++ b/League/package.json
@@ -22,8 +22,6 @@
         "grunt-postcss": "0.9.0",
         "grunt-sass": "3.1.0",
         "jquery": "3.5.1",
-        "jquery-validation": "1.19.5",
-        "jquery-validation-unobtrusive": "3.2.12",
         "js-cookie": "2.2.1",
         "jsnlog": "2.30.0",
         "moment": "2.29.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Src",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
**Reasoning** to remove jQuery based client validation:
Bootstrap 5 and other packages move from jQuery to plain vanilla javascript. Asp.Net 7 templates come with jQuery included.

* Set `MvcViewOptions.HtmlHelperOptions.ClientValidationEnabled = false` globally in Starup
* Remove npm packages jquery-validation and jquery-validation-unobtrusive
* Remove individual setting for `ViewContext.ClientValidationEnabled` in views