### PR TITLE
style: Clearer wording regarding displayed contact details

### DIFF
--- a/League/Views/Team/Single.cshtml
+++ b/League/Views/Team/Single.cshtml
@@ -76,7 +76,7 @@
             else
             {
                 <div class="text-success col-md-3">@Localizer["Team contact"]</div>
-                <div class="col-md-7 mb-2">@Localizer["Contacts are only displayed to members of any team"].</div>
+                <div class="col-md-7 mb-2"><strong>@Localizer["Contacts are displayed only to signed-in users who are members of a team."]</strong></div>
             }
         }
         <div class="text-success col-md-3">@Localizer["Team Photo"]</div>

--- a/League/Views/Team/Single.de.resx
+++ b/League/Views/Team/Single.de.resx
@@ -120,8 +120,8 @@
   <data name="Club" xml:space="preserve">
     <value>Verein</value>
   </data>
-  <data name="Contacts are only displayed to members of any team" xml:space="preserve">
-    <value>Kontakte werden nur Mitgliedern eines der Teams angezeigt</value>
+  <data name="Contacts are displayed only to signed-in users who are members of a team." xml:space="preserve">
+    <value>Kontakte werden nur angemeldeten Benutzern angezeigt, die Mitglied eines Teams sind.</value>
   </data>
   <data name="Direction" xml:space="preserve">
     <value>Anfahrt</value>


### PR DESCRIPTION
"Contacts are displayed only to signed-in users who are members of a team."