### PR TITLE
Remove Microsoft.AspNetCore.WebUtilities from project Axuno.Web

### DIFF
--- a/Axuno.Web/Axuno.Web.csproj
+++ b/Axuno.Web/Axuno.Web.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
+        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.31.0" />
         <PackageReference Include="NuGetizer" Version="1.0.4">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Axuno.Web/UrlEncoding.cs
+++ b/Axuno.Web/UrlEncoding.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using Microsoft.AspNetCore.WebUtilities;
-using System.Text;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Axuno.Web;
 
@@ -12,8 +11,7 @@ public static class UrlEncoding
     /// </summary>
     public static string Base64UrlEncode(this string code)
     {
-        var codeBytes = Encoding.UTF8.GetBytes(code);
-        return WebEncoders.Base64UrlEncode(codeBytes);
+        return Base64UrlEncoder.Encode(code);
     }
 
     /// <summary>
@@ -24,8 +22,7 @@ public static class UrlEncoding
     {
         try
         {
-            var decodedBytes = WebEncoders.Base64UrlDecode(encodedString);
-            return Encoding.UTF8.GetString(decodedBytes);
+            return Base64UrlEncoder.Decode(encodedString);
         }
         catch (Exception)
         {


### PR DESCRIPTION
Replace `Microsoft.AspNetCore.WebUtilities` with `Microsoft.IdentityModel.Tokens` It was used in `UrlEncoding.Base64UrlEncode(...)` and `UrlEncoding.Base64UrlDecode(...)`

Reasoning: **All versions of `Microsoft.AspNetCore.WebUtilities` v2.2.0 and before are depreciated.**