### PR TITLE
Don't throw for missing tournament id in database

### DIFF
--- a/League/Controllers/AbstractController.cs
+++ b/League/Controllers/AbstractController.cs
@@ -33,9 +33,10 @@ public abstract class AbstractController : Controller
     /// <returns>Gets the <see cref="System.Security.Claims.ClaimTypes.NameIdentifier"/> of the current user
     /// as <see langword="long"/> integer.</returns>
     [NonAction]
-    protected long GetCurrentUserId()
+    protected long? GetCurrentUserId()
     {
-        return long.Parse(User.Claims.First(c => c.Type == System.Security.Claims.ClaimTypes.NameIdentifier).Value);
+        var userId = User.Claims.FirstOrDefault(c => c.Type == System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        return long.TryParse(userId, out var id) ? id : null;
     }
 
     /// <summary>

--- a/League/Controllers/Ranking.cs
+++ b/League/Controllers/Ranking.cs
@@ -63,7 +63,8 @@ public class Ranking : AbstractController
 
             if (model.Tournament == null)
             {
-                throw new Exception($"{nameof(_tenantContext.TournamentContext.MatchResultTournamentId)} '{_tenantContext.TournamentContext.MatchResultTournamentId}' does not exist");
+                _logger.LogCritical("{name} '{id}' does not exist. User ID '{currentUser}'.", nameof(_tenantContext.TournamentContext.MatchPlanTournamentId), _tenantContext.TournamentContext.MatchResultTournamentId, GetCurrentUserId());
+                return NotFound();
             }
 
             return View(Views.ViewNames.Ranking.Table, model);
@@ -71,7 +72,7 @@ public class Ranking : AbstractController
         catch (Exception e)
         {
             _logger.LogCritical(e, "Error when creating the ranking table");
-            throw;
+            return NotFound();
         }
     }
 

--- a/League/Controllers/TeamApplication.cs
+++ b/League/Controllers/TeamApplication.cs
@@ -525,7 +525,7 @@ public class TeamApplication : AbstractController
                         TeamId = teamInRoundEntity.TeamId,
                         IsNewApplication = isNewApplication,
                         RoundId = teamInRoundEntity.RoundId,
-                        RegisteredByUserId = GetCurrentUserId(),
+                        RegisteredByUserId = GetCurrentUserId() ?? throw new InvalidOperationException("Current user ID must not be null"),
                         UrlToEditApplication = TenantLink.ActionLink(nameof(EditTeam), nameof(TeamApplication), new { teamId = teamInRoundEntity.TeamId }, scheme: Request.Scheme, host: Request.Host) ?? string.Empty
                     }
                 });
@@ -697,11 +697,6 @@ public class TeamApplication : AbstractController
         var previousTournament = await _appDb.TournamentRepository.GetTournamentAsync(
             new PredicateExpression(TournamentFields.NextTournamentId == _tenantContext.TournamentContext.ApplicationTournamentId),
             cancellationToken);
-        if (previousTournament == null)
-        {
-            _logger.LogCritical("No tournament found for ID '{ApplicationTournamentId}'", _tenantContext.TournamentContext.ApplicationTournamentId);
-            throw new InvalidOperationException($"No tournament found for ID '{_tenantContext.TournamentContext.ApplicationTournamentId}'");
-        }
         
         return new ApplicationSessionModel
         {
@@ -709,7 +704,7 @@ public class TeamApplication : AbstractController
             Team = new TeamEditorComponentModel {HtmlFieldPrefix = nameof(ApplicationSessionModel.Team), IsNew = true},
             Venue = new VenueEditorComponentModel {HtmlFieldPrefix = nameof(ApplicationSessionModel.Venue), IsNew = true},
             TournamentName = teamApplicationTournament.Name,
-            PreviousTournamentId = previousTournament.Id
+            PreviousTournamentId = previousTournament?.Id
         };
     }
 
@@ -741,7 +736,7 @@ public class TeamApplication : AbstractController
         {
             var mot = teamEntity.ManagerOfTeams.AddNew();
             mot.Team = teamEntity;
-            mot.UserId = GetCurrentUserId();
+            mot.UserId = GetCurrentUserId() ?? throw new InvalidOperationException("Current user ID must not be null");
         }
         else
         {
@@ -752,7 +747,7 @@ public class TeamApplication : AbstractController
             {
                 mot = teamEntity.ManagerOfTeams.AddNew();
                 mot.TeamId = teamEntity.Id;
-                mot.UserId = GetCurrentUserId();
+                mot.UserId = GetCurrentUserId() ?? throw new InvalidOperationException("Current user ID must not be null");
             }
         }
     }


### PR DESCRIPTION
* `Match`, `Ranking` and `TeamApplication` `Controller`s don't throw any more, when a tournament id from `TenantContext` does not exist in the database. Instead, a critical error is logged.
* `GetCurrentUserId()` from `AbstractController` returns `null`, if the `ClaimTypes.NameIdentifier` is missing unexpectedly. The caller will throw an `InvalidOperationException` when `null` is not allowed