### PR TITLE
Enable null for team venue and home match day/time

### DIFF
--- a/League/Components/VenueEditorComponentModel.cs
+++ b/League/Components/VenueEditorComponentModel.cs
@@ -8,7 +8,7 @@ namespace League.Components;
 public class VenueEditorComponentModel
 {
     [HiddenInput]
-    public long Id { get; set; }
+    public long? Id { get; set; }
 
     [HiddenInput]
     public bool IsNew { get; set; }
@@ -81,7 +81,7 @@ public class VenueEditorComponentModel
     {
         // The entity is populated from the database,
         // so we can track all eventual changes to fields
-        venueEntity.Id = IsNew ? default : Id;
+        venueEntity.Id = IsNew ? default : Id ?? default;
         venueEntity.IsNew = IsNew;
         venueEntity.Name = Name;
         venueEntity.Extension = Extension;
@@ -89,7 +89,7 @@ public class VenueEditorComponentModel
         venueEntity.City = City;
         venueEntity.Street = Street;
         venueEntity.Direction = Direction;
-        if (venueEntity.Longitude.HasValue && venueEntity.Latitude.HasValue)
+        if (venueEntity is { Longitude: null, Latitude: null })
         {
             venueEntity.Longitude = Longitude;
             venueEntity.Latitude = Latitude;

--- a/League/Components/VenueSelector.cs
+++ b/League/Components/VenueSelector.cs
@@ -6,13 +6,11 @@ namespace League.Components;
 
 public class VenueSelector : ViewComponent
 {
-    private readonly ITenantContext _tenantContext;
-    private readonly TournamentManager.MultiTenancy.AppDb _appDb;
+    private readonly AppDb _appDb;
     private readonly ILogger<VenueSelector> _logger;
 
     public VenueSelector(ITenantContext tenantContext, ILogger<VenueSelector> logger)
     {
-        _tenantContext = tenantContext;
         _appDb = tenantContext.DbContext.AppDb;
         _logger = logger;
     }

--- a/League/Models/TeamApplicationViewModels/ApplicationSessionModel.cs
+++ b/League/Models/TeamApplicationViewModels/ApplicationSessionModel.cs
@@ -4,6 +4,14 @@ namespace League.Models.TeamApplicationViewModels;
 
 public class ApplicationSessionModel
 {
+    public enum TeamVenueSetKind
+    {
+        NotSet = 0,
+        NoVenue,
+        ExistingVenue,
+        NewVenue
+    }
+
     /// <summary>
     /// The state of the model will be set to <see langword="true"/> whenever it is restored from a session.
     /// </summary>
@@ -15,7 +23,7 @@ public class ApplicationSessionModel
     public bool TeamIsSet { get; set; } = false;
     public TeamEditorComponentModel? Team { get; set; }
 
-    public bool VenueIsSet { get; set; } = false;
+    public TeamVenueSetKind VenueIsSet { get; set; } = TeamVenueSetKind.NotSet;
     public VenueEditorComponentModel? Venue { get; set; }
 
     /// <summary>

--- a/League/Models/TeamViewModels/TeamVenueSelectModel.cs
+++ b/League/Models/TeamViewModels/TeamVenueSelectModel.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using TournamentManager.ModelValidators;
 
 namespace League.Models.TeamViewModels;
 
@@ -12,4 +13,15 @@ public class TeamVenueSelectModel
     public long? VenueId { get; set; }
     [HiddenInput] 
     public string ReturnUrl { get; set; } = string.Empty;
+
+    public async Task<bool> ValidateAsync(TeamVenueValidator teamValidator, ModelStateDictionary modelState, CancellationToken cancellationToken)
+    {
+        var fact = await teamValidator.CheckAsync(TeamVenueValidator.FactId.VenueIsSetIfRequired, cancellationToken);
+        if (fact is { IsChecked: true, Success: false }) modelState.AddModelError(fact.FieldNames.First(), fact.Message);
+
+        fact = await teamValidator.CheckAsync(TeamVenueValidator.FactId.VenueIsValid, cancellationToken);
+        if (fact is { IsChecked: true, Success: false }) modelState.AddModelError(fact.FieldNames.First(), fact.Message);
+
+        return modelState.IsValid;
+    }
 }

--- a/League/Views/Shared/Components/TeamEditor/Default.cshtml
+++ b/League/Views/Shared/Components/TeamEditor/Default.cshtml
@@ -67,15 +67,18 @@ ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = Model.HtmlFieldPrefix;
 <script type="text/javascript" site-on-modal-shown="true" site-on-content-loaded="true">
     const onMatchDayOfWeekChangeFunction = function() {
         const matchTimeEle = document.getElementById('@Html.IdFor(m => m.MatchTime)');
+        const matchTimeSpanEle = document.querySelector('span[data-td-target="@nameof(Model.MatchTime)-c"]');
         if (this.value === '') {
-            matchTimeEle.setAttribute('disabled', 'disabled');
-            matchTimeEle.style.cursor = 'not-allowed';
             matchTimeEle.value = '';
-            document.querySelector('span[data-td-target="@nameof(Model.MatchTime)-c"]').style.cursor = 'not-allowed';
+            matchTimeEle.setAttribute('readonly', '');
+            matchTimeEle.style.cursor = 'not-allowed';
+            matchTimeEle.style.backgroundColor = 'var(--bs-gray-100)';
+            matchTimeSpanEle.style.display = 'none';
         } else {
-            matchTimeEle.removeAttribute('disabled');
+            matchTimeEle.removeAttribute('readonly');
             matchTimeEle.style.cursor = 'auto';
-            document.querySelector('span[data-td-target="@nameof(Model.MatchTime)-c"]').style.cursor = 'pointer';
+            matchTimeEle.style.backgroundColor = '';
+            matchTimeSpanEle.style.display = 'block';
         }
     };
     const matchDayOfWeek = document.getElementById('@Html.IdFor(m => m.MatchDayOfWeek)');

--- a/League/Views/Shared/Components/TeamEditor/Default.de.resx
+++ b/League/Views/Shared/Components/TeamEditor/Default.de.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Not specified" xml:space="preserve">
-    <value>Nicht bestimmt</value>
+    <value>Nicht festgelegt</value>
   </data>
   <data name="Please select a weekday" xml:space="preserve">
     <value>Bitte einen Wochentag auswählen</value>

--- a/League/Views/Shared/Components/VenueEditor/Default.de.resx
+++ b/League/Views/Shared/Components/VenueEditor/Default.de.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Not specified" xml:space="preserve">
-    <value>Nicht bestimmt</value>
+    <value>Nicht festgelegt</value>
   </data>
   <data name="Please select a weekday" xml:space="preserve">
     <value>Bitte einen Wochentag auswählen</value>

--- a/League/Views/Shared/Components/VenueSelector/Default.cshtml
+++ b/League/Views/Shared/Components/VenueSelector/Default.cshtml
@@ -1,5 +1,6 @@
 ﻿@using League.Components
 @using Microsoft.AspNetCore.Mvc.Localization
+@using TournamentManager.MultiTenancy
 @inject IViewLocalizer Localizer
 @model VenueSelectorComponentModel
 @{
@@ -22,9 +23,9 @@
         </tr>
         </thead>
         <tbody>
-        @if ((Model.Filter & VenueSelectorComponentModel.Criteria.NotSpecified) == VenueSelectorComponentModel.Criteria.NotSpecified && Model.VenueNotSpecifiedKey.HasValue)
+        @if ((Model.Filter & VenueSelectorComponentModel.Criteria.NotSpecified) == VenueSelectorComponentModel.Criteria.NotSpecified)
         {
-            <tr data-venue-id="@Model.VenueNotSpecifiedKey"><td></td><td colspan="2">@Localizer["Not specified"]</td></tr>
+                <tr data-venue-id="@Model.VenueNotSpecifiedKey"><td></td><td colspan="2">@Localizer["There is no venue assigned"]</td></tr>
         }
         @if (Model.Filter == VenueSelectorComponentModel.Criteria.AllVenues)
         {

--- a/League/Views/Shared/Components/VenueSelector/Default.de.resx
+++ b/League/Views/Shared/Components/VenueSelector/Default.de.resx
@@ -132,9 +132,6 @@
   <data name="No venues found at this time" xml:space="preserve">
     <value>Keine Spielorte gefunden</value>
   </data>
-  <data name="Not specified" xml:space="preserve">
-    <value>Nicht festgelegt</value>
-  </data>
   <data name="Other venues" xml:space="preserve">
     <value>Andere Spielorte</value>
   </data>
@@ -143,5 +140,8 @@
   </data>
   <data name="Team venues" xml:space="preserve">
     <value>Team Spielorte</value>
+  </data>
+  <data name="There is no venue assigned" xml:space="preserve">
+    <value>Kein Spielort zugeordnet</value>
   </data>
 </root>

--- a/League/Views/Team/MyTeam.cshtml
+++ b/League/Views/Team/MyTeam.cshtml
@@ -69,11 +69,16 @@
                             <div class="text-success col-12">@Localizer["Club"]</div>
                             <div class="col-12">@teamVenueInfo.TeamClubName</div>
                         }
-                        @if (teamVenueInfo.MatchDayOfWeek.HasValue && teamVenueInfo.MatchTime.HasValue)
+                        @if (teamVenueInfo is { MatchDayOfWeek: not null, MatchTime: not null })
                         {
                             // MatchTime is defined as a zoned time, NOT UTC. It is always the same, never mind DST
                             <div class="text-success col-12">@Localizer["Home match day"]</div>
                             <div class="col-12 mb-2"><i class="far fa-calendar-alt"></i><span class="d-inline-block me-2"></span>@DateTimeFormatInfo.CurrentInfo?.GetDayName((DayOfWeek)teamVenueInfo.MatchDayOfWeek), @(DateTime.UtcNow.Date.Add(teamVenueInfo.MatchTime.Value).ToShortTimeString()) @(Model.TimeZoneConverter.ToZonedTime(DateTime.UtcNow)?.Abbreviation)</div>
+                        }
+                        else
+                        {
+                            <div class="text-success col-12">@Localizer["Home match day"]</div>
+                            <div class="col-12 mb-2">[@(Localizer["Not specified"])]</div>
                         }
                         <div class="text-muted small col-12">
                             @{ var zonedTime = Model.TimeZoneConverter.ToZonedTime(teamVenueInfo.TeamModifiedOn)!;}
@@ -149,7 +154,7 @@
                                 {
                                     <div>
                                         <i class="fas fa-map-marker-alt"></i><span class="d-inline-block me-2"></span>
-                                        @Localizer["There is no venue assigned to the team"].
+                                        [@(Localizer["There is no venue assigned to the team"])]
                                     </div>
                                 }
                             </div>

--- a/League/Views/Team/MyTeam.de.resx
+++ b/League/Views/Team/MyTeam.de.resx
@@ -144,6 +144,9 @@
   <data name="No team photo has been uploaded" xml:space="preserve">
     <value>Es wurde kein Foto hochgeladen</value>
   </data>
+  <data name="Not specified" xml:space="preserve">
+    <value>Nicht festgelegt</value>
+  </data>
   <data name="Photo of {0}" xml:space="preserve">
     <value>Foto vom {0}</value>
   </data>

--- a/League/Views/Team/Single.cshtml
+++ b/League/Views/Team/Single.cshtml
@@ -32,22 +32,49 @@
             <div class="text-success col-md-3">@Localizer["Club"]</div>
             <div class="col-md-9">@Model.TeamVenueRoundInfo.TeamClubName</div>
         }
-        @if (Model.TeamVenueRoundInfo.MatchDayOfWeek.HasValue && Model.TeamVenueRoundInfo.MatchTime.HasValue)
-        {
-            // MatchTime is defined as a zoned time, NOT UTC. It is always the same, never mind DST
-            <div class="text-success col-md-3">@Localizer["Home match day"]</div>
-            <div class="col-md-9 mb-2"><i class="far fa-calendar-alt"></i><span class="d-inline-block me-2"></span>@DateTimeFormatInfo.CurrentInfo.GetDayName((DayOfWeek)Model.TeamVenueRoundInfo.MatchDayOfWeek), @(DateTime.UtcNow.Date.Add(Model.TeamVenueRoundInfo.MatchTime.Value).ToShortTimeString()) @(Model.TimeZoneConverter.ToZonedTime(DateTime.UtcNow)!.Abbreviation)</div>
-        }
-        @if (Model.TeamVenueRoundInfo.VenueId.HasValue)
-        {
-            <div class="text-success col-md-3">@Localizer["Venue"]</div>
-            <div class="col-md-7 mb-2">
-                <div><i class="fas fa-map-marker-alt"></i><span class="d-inline-block me-2"></span><span class="fw-bold">@Model.TeamVenueRoundInfo.VenueName</span> <span>@{if (!string.IsNullOrWhiteSpace(Model.TeamVenueRoundInfo.VenueExtension))
-                    {<text>(@Model.TeamVenueRoundInfo.VenueExtension)</text>}}</span></div>
-                <div>@(string.Join(", ", Model.TeamVenueRoundInfo.VenuePostalCode, Model.TeamVenueRoundInfo.VenueCity, Model.TeamVenueRoundInfo.VenueStreet))</div>
-                <div><a class="link" asp-action="@nameof(League.Controllers.Map.Venue)" asp-controller="@nameof(League.Controllers.Map)" asp-route-tenant="@tenantUrlSegment" asp-route-id="@Model.TeamVenueRoundInfo.VenueId.Value">@Localizer["Direction"]</a></div>
-            </div>
-        }
+        
+        <div class="text-success col-md-3">@Localizer["Home match day"]</div>
+        <div class="col-md-9 mb-2">
+            @if (Model.TeamVenueRoundInfo.MatchDayOfWeek.HasValue && Model.TeamVenueRoundInfo.MatchTime.HasValue)
+            {
+                @* MatchTime is defined as a zoned time, NOT UTC. It is always the same, never mind DST*@
+                <i class="far fa-calendar-alt"></i><span class="d-inline-block me-2"></span>@DateTimeFormatInfo.CurrentInfo.GetDayName((DayOfWeek)Model.TeamVenueRoundInfo.MatchDayOfWeek)<text>, </text> 
+                @(DateTime.UtcNow.Date.Add(Model.TeamVenueRoundInfo.MatchTime.Value).ToShortTimeString())<text> </text>@(Model.TimeZoneConverter.ToZonedTime(DateTime.UtcNow)!.Abbreviation)
+            }
+            else
+            {
+                <span>[@(Localizer["Not specified"])]</span>
+            }
+        </div>
+
+        <div class="text-success col-md-3">@Localizer["Venue"]</div>
+        <div class="col-md-7 mb-2">
+            @if (Model.TeamVenueRoundInfo.VenueId.HasValue)
+            {
+                <div>
+                    <i class="fas fa-map-marker-alt"></i><span class="d-inline-block me-2"></span><span class="fw-bold">@Model.TeamVenueRoundInfo.VenueName</span>
+                    <span>
+                        @{
+                            if (!string.IsNullOrWhiteSpace(Model.TeamVenueRoundInfo.VenueExtension))
+                            {
+                                <text>(@Model.TeamVenueRoundInfo.VenueExtension)</text>
+                            }
+                        }
+                    </span>
+                </div>
+                <div>
+                    @(string.Join(", ", Model.TeamVenueRoundInfo.VenuePostalCode, Model.TeamVenueRoundInfo.VenueCity, Model.TeamVenueRoundInfo.VenueStreet))
+                </div>
+                <div>
+                    <a class="link" asp-action="@nameof(League.Controllers.Map.Venue)" asp-controller="@nameof(League.Controllers.Map)" asp-route-tenant="@tenantUrlSegment" asp-route-id="@Model.TeamVenueRoundInfo.VenueId.Value">@Localizer["Direction"]</a>
+                </div>
+            }
+            else
+            {
+                <span>[@(Localizer["There is no venue assigned to the team"])]</span>
+            }
+        </div>
+        
         @if (Model.TeamUserRoundInfos.Count > 0)
         {
             @if (Model.ShowContactInfos)

--- a/League/Views/Team/Single.de.resx
+++ b/League/Views/Team/Single.de.resx
@@ -129,6 +129,9 @@
   <data name="Home match day" xml:space="preserve">
     <value>Heimspieltag</value>
   </data>
+  <data name="Not specified" xml:space="preserve">
+    <value>Nicht festgelegt</value>
+  </data>
   <data name="Photo of" xml:space="preserve">
     <value>Foto vom</value>
   </data>
@@ -143,6 +146,9 @@
   </data>
   <data name="Team Photo" xml:space="preserve">
     <value>Teamfoto</value>
+  </data>
+  <data name="There is no venue assigned to the team" xml:space="preserve">
+    <value>Dem Team ist kein Spielort zugeordnet</value>
   </data>
   <data name="Venue" xml:space="preserve">
     <value>Spielort</value>

--- a/League/Views/Team/_MyTeamMessagesPartial.Designer.cs
+++ b/League/Views/Team/_MyTeamMessagesPartial.Designer.cs
@@ -19,7 +19,7 @@ namespace League.Views.Team {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class _MyTeamMessagesPartial {
@@ -160,7 +160,7 @@ namespace League.Views.Team {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Saving the selected team venue has failed.
+        ///   Looks up a localized string similar to Changing the selected team venue has failed.
         /// </summary>
         public static string VenueSelectFailure {
             get {
@@ -169,7 +169,7 @@ namespace League.Views.Team {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The selected team venue has been saved successfully.
+        ///   Looks up a localized string similar to The selected team venue has been changed successfully.
         /// </summary>
         public static string VenueSelectSuccess {
             get {

--- a/League/Views/Team/_MyTeamMessagesPartial.cshtml
+++ b/League/Views/Team/_MyTeamMessagesPartial.cshtml
@@ -13,7 +13,7 @@
                 W‌rite(_MyTeamMessagesPartial.TeamDataSuccess);
                 break;
             case MyTeamMessageModel.MessageId.TeamDataFailure:
-                W‌rite(_MyTeamMessagesPartial.TeamDataSuccess);
+                W‌rite(_MyTeamMessagesPartial.TeamDataFailure);
                 break;
             case MyTeamMessageModel.MessageId.MemberAddSuccess:
                 W‌rite(_MyTeamMessagesPartial.MemberAddSuccess);

--- a/League/Views/Team/_MyTeamMessagesPartial.de.resx
+++ b/League/Views/Team/_MyTeamMessagesPartial.de.resx
@@ -151,7 +151,7 @@
     <value>Geänderte Spielortdaten wurden gespeichert</value>
   </data>
   <data name="VenueSelectFailure" xml:space="preserve">
-    <value>Speichern des gewählten Spielort des Teams ist fehlgeschlagen</value>
+    <value>Ändern des Spielorts für das Teams ist fehlgeschlagen</value>
   </data>
   <data name="VenueSelectSuccess" xml:space="preserve">
     <value>Der gewählte Spielort des Teams wurde gespeichert</value>

--- a/League/Views/Team/_SelectVenueModalPartial.cshtml
+++ b/League/Views/Team/_SelectVenueModalPartial.cshtml
@@ -1,6 +1,7 @@
 @using League.Controllers
 @using Microsoft.AspNetCore.Mvc.Localization
 @using TournamentManager.MultiTenancy
+@using League.Components
 @inject IViewLocalizer Localizer
 @inject ITenantContext TenantContext
 @model League.Models.TeamViewModels.TeamVenueSelectModel
@@ -8,13 +9,14 @@
 <!-- Modal -->
 <modal id="select-venue" title="@Localizer["Select team venue"].Value" dialog-class="modal-lg" tabindex="-1">
     <modal-body class="pb-0">
-        @{ ValueTuple<long, IList<long>, League.Components.VenueSelectorComponentModel.Criteria, League.Components.VenueSelectorComponentModel.Criteria, long?> componentModel =
+        @{ ValueTuple<long, IList<long>, VenueSelectorComponentModel.Criteria, VenueSelectorComponentModel.Criteria, long?> componentModel =
                  (Model.TournamentId,
                      new List<long>(new[] { Model.TeamId }),
-                     League.Components.VenueSelectorComponentModel.Criteria.VenuesOfTeams | League.Components.VenueSelectorComponentModel.Criteria.Active | League.Components.VenueSelectorComponentModel.Criteria.Unused,
-                     League.Components.VenueSelectorComponentModel.Criteria.VenuesOfTeams | League.Components.VenueSelectorComponentModel.Criteria.Active | League.Components.VenueSelectorComponentModel.Criteria.Unused,
-                     default(long?)); }
-        @(await Component.InvokeAsync<League.Components.VenueSelector>(componentModel))
+                     (!TenantContext.TournamentContext.TeamRuleSet.HomeVenue.MustBeSet ? VenueSelectorComponentModel.Criteria.NotSpecified : 0) |
+                     VenueSelectorComponentModel.Criteria.VenuesOfTeams | VenueSelectorComponentModel.Criteria.Active | VenueSelectorComponentModel.Criteria.Unused,
+                     VenueSelectorComponentModel.Criteria.VenuesOfTeams | VenueSelectorComponentModel.Criteria.Active | VenueSelectorComponentModel.Criteria.Unused,
+                     default); }
+        @(await Component.InvokeAsync<VenueSelector>(componentModel))
         <form asp-controller="@nameof(Team)" asp-action="@nameof(Team.SelectVenue)" asp-route-tenant="@tenantUrlSegment" method="post" novalidate>
             <input asp-for="TeamId" type="hidden" />
             <input asp-for="VenueId" type="hidden" />

--- a/League/Views/TeamApplication/Confirm.cshtml
+++ b/League/Views/TeamApplication/Confirm.cshtml
@@ -1,6 +1,7 @@
 ﻿@using System.Globalization
 @using Axuno.Tools.DateAndTime
 @using League.Controllers
+@using League.Models.TeamApplicationViewModels
 @using Microsoft.AspNetCore.Mvc.Localization
 @using TournamentManager.MultiTenancy
 @inject IViewLocalizer Localizer
@@ -27,30 +28,55 @@
             <div class="text-success col-md-3">@Localizer["Club"]</div>
             <div class="col-md-9">@Model.SessionModel.Team.ClubName</div>
         }
+        
+        <div class="text-success col-md-3">@Localizer["Home match day"]</div>
+        <div class="col-md-9">
         @if (Model.SessionModel.Team.MatchDayOfWeek.HasValue && Model.SessionModel.Team.MatchTime.HasValue)
         {
             // MatchTime is defined as a zoned time, NOT UTC. It is always the same, never mind DST
-            <div class="text-success col-md-3">@Localizer["Home match day"]</div>
-            <div class="col-md-9 mb-2"><i class="far fa-calendar-alt"></i><span class="d-inline-block me-2"></span>@DateTimeFormatInfo.CurrentInfo.GetDayName((DayOfWeek)Model.SessionModel.Team.MatchDayOfWeek), @(DateTime.UtcNow.Date.Add(Model.SessionModel.Team.MatchTime.Value.ToTimeSpan()).ToShortTimeString()) @(TimeZoneConverter.ToZonedTime(DateTime.UtcNow)!.Abbreviation)</div>
+            <i class="far fa-calendar-alt"></i><span class="d-inline-block me-2"></span>
+            @DateTimeFormatInfo.CurrentInfo.GetDayName((DayOfWeek)Model.SessionModel.Team.MatchDayOfWeek)<text>, </text>@(DateTime.UtcNow.Date.Add(Model.SessionModel.Team.MatchTime.Value.ToTimeSpan()).ToShortTimeString())<text> </text>@(TimeZoneConverter.ToZonedTime(DateTime.UtcNow)!.Abbreviation)
         }
-        <div class="text-success col-md-3">@(Model.SessionModel.Venue!.IsNew ? Localizer["New venue"] : Localizer["Existing venue"])</div>
-        <div class="col-md-7 mb-2">
-            <div><i class="fas fa-map-marker-alt"></i><span class="d-inline-block me-2"></span><span class="fw-bold">@Model.SessionModel.Venue.Name</span></div>
-            <div>@(string.Join(", ", Model.SessionModel.Venue.PostalCode, Model.SessionModel.Venue.City, Model.SessionModel.Venue.Street))</div>
-        </div>
-        @if (!string.IsNullOrWhiteSpace(Model.SessionModel.Venue.Direction))
+        else
         {
-            <div class="text-success col-md-3">@Localizer["Directions, hints"]</div>
+            <span>[@(Localizer["Not specified"])]</span>
+        }
+        </div>
+        @if (Model.SessionModel.VenueIsSet == ApplicationSessionModel.TeamVenueSetKind.NoVenue)
+        {
+            <div class="text-success col-md-3">@Localizer["Venue"]</div>
             <div class="col-md-7 mb-2">
-                <div><i class="fas fa-info-circle"></i><span class="d-inline-block me-2"></span>@Model.SessionModel.Venue.Direction</div>
+                [@(Localizer["There is no venue assigned to the team"])]
             </div>
+        }
+        else
+        {
+            <div class="text-success col-md-3">@(Model.SessionModel.Venue!.IsNew ? Localizer["New venue"] : Localizer["Existing venue"])</div>
+            <div class="col-md-7 mb-2">
+                <div><i class="fas fa-map-marker-alt"></i><span class="d-inline-block me-2"></span><span class="fw-bold">@Model.SessionModel.Venue.Name</span></div>
+                <div>@(string.Join(", ", Model.SessionModel.Venue.PostalCode, Model.SessionModel.Venue.City, Model.SessionModel.Venue.Street))</div>
+            </div>
+            @if (!string.IsNullOrWhiteSpace(Model.SessionModel.Venue.Direction))
+            {
+                <div class="text-success col-md-3">@Localizer["Directions, hints"]</div>
+                <div class="col-md-7 mb-2">
+                    <div><i class="fas fa-info-circle"></i><span class="d-inline-block me-2"></span>@Model.SessionModel.Venue.Direction</div>
+                </div>
+            }
         }
     </div>
     <div class="row">
         <div class="mb-3 col-12 col-md-6">
             <form asp-controller="@nameof(TeamApplication)" asp-action="@nameof(TeamApplication.Confirm)" asp-route-tenant="@tenantUrlSegment" method="post" role="form" novalidate>
-                <a asp-controller="@nameof(TeamApplication)" asp-action="@nameof(TeamApplication.EditVenue)" asp-route-tenant="@tenantUrlSegment" class="btn btn-secondary d-inline-block">@Localizer["Back"]</a>
-                <input type="hidden" id="Done" name="Done" value="true" />
+                @if (Model.SessionModel.VenueIsSet == ApplicationSessionModel.TeamVenueSetKind.NoVenue)
+                {
+                    <a asp-controller="@nameof(TeamApplication)" asp-action="@nameof(TeamApplication.SelectVenue)" asp-route-tenant="@tenantUrlSegment" class="btn btn-secondary d-inline-block">@Localizer["Back"]</a>
+                }
+                else
+                {
+                    <a asp-controller="@nameof(TeamApplication)" asp-action="@nameof(TeamApplication.EditVenue)" asp-route-tenant="@tenantUrlSegment" class="btn btn-secondary d-inline-block">@Localizer["Back"]</a>
+                }
+                <input type="hidden" id="Done" name="Done" value="true"/>
                 <button type="submit" class="btn btn-primary d-inline-block ">@Localizer["Confirm and save"]</button>
             </form>
         </div>

--- a/League/Views/TeamApplication/Confirm.de.resx
+++ b/League/Views/TeamApplication/Confirm.de.resx
@@ -150,4 +150,13 @@
   <data name="Round" xml:space="preserve">
     <value>Runde</value>
   </data>
+  <data name="There is no venue assigned to the team" xml:space="preserve">
+    <value>Dem Team ist kein Spielort zugeordnet</value>
+  </data>
+  <data name="Venue" xml:space="preserve">
+    <value>Spielort</value>
+  </data>
+  <data name="Not specified" xml:space="preserve">
+    <value>Nicht festgelegt</value>
+  </data>
 </root>

--- a/League/Views/TeamApplication/SelectVenue.cshtml
+++ b/League/Views/TeamApplication/SelectVenue.cshtml
@@ -1,22 +1,24 @@
 @using League.Controllers
 @using Microsoft.AspNetCore.Mvc.Localization
 @using TournamentManager.MultiTenancy
+@using League.Components
 @inject IViewLocalizer Localizer
 @inject ITenantContext TenantContext
 @model League.Models.TeamViewModels.TeamVenueSelectModel
-@{ ValueTuple<long, IList<long>, League.Components.VenueSelectorComponentModel.Criteria, League.Components.VenueSelectorComponentModel.Criteria, long?> componentModel =
+@{ ValueTuple<long, IList<long>, VenueSelectorComponentModel.Criteria, VenueSelectorComponentModel.Criteria, long?> componentModel =
           (Model.TournamentId,
               new List<long>(new[] { Model.TeamId }),
-              League.Components.VenueSelectorComponentModel.Criteria.VenuesOfTeams | League.Components.VenueSelectorComponentModel.Criteria.Active | League.Components.VenueSelectorComponentModel.Criteria.Unused,
-              League.Components.VenueSelectorComponentModel.Criteria.VenuesOfTeams | League.Components.VenueSelectorComponentModel.Criteria.Active | League.Components.VenueSelectorComponentModel.Criteria.Unused,
-              default(long?));
+              (!TenantContext.TournamentContext.TeamRuleSet.HomeVenue.MustBeSet ? VenueSelectorComponentModel.Criteria.NotSpecified : 0) |
+              VenueSelectorComponentModel.Criteria.VenuesOfTeams | VenueSelectorComponentModel.Criteria.Active | VenueSelectorComponentModel.Criteria.Unused,
+              VenueSelectorComponentModel.Criteria.VenuesOfTeams | VenueSelectorComponentModel.Criteria.Active | VenueSelectorComponentModel.Criteria.Unused,
+              default);
     ViewData["Title"] = Localizer["Team Registration"].Value + " - " + ViewData["TournamentName"];
     var tenantUrlSegment = TenantContext.SiteContext.UrlSegmentValue;
 }
 <div class="mb-0 pb-2">
     <h2 class="h2">@ViewData["Title"]</h2>
     <hr class="mb-3" />
-    @(await Component.InvokeAsync<League.Components.VenueSelector>(componentModel))
+    @(await Component.InvokeAsync<VenueSelector>(componentModel))
     <form asp-controller="@nameof(TeamApplication)" asp-action="@nameof(TeamApplication.SelectVenue)" asp-route-tenant="@tenantUrlSegment" method="post" novalidate>
         <input asp-for="TeamId" type="hidden" />
         <input asp-for="VenueId" type="hidden" />

--- a/League/Views/TeamApplication/Start.cshtml
+++ b/League/Views/TeamApplication/Start.cshtml
@@ -17,7 +17,7 @@
         <div class="col-12">
             <h4 class="h4">Who can register</h4>
             <p>
-                Eligible team members can easily register their team for the next season.
+                Team contacts can easily register their team for the next season.
                 This applies to all teams that have ever participated in a season.
             </p>
             <p>
@@ -37,9 +37,9 @@
             <p>
                 To ensure that the match day can be determined automatically and without overlap, please note the following:
                 <ul>
-                    <li>All teams using one field of a venue at the same time must select that venue.</li>
+                    <li>All teams using one field of a venue at the same time <strong>must</strong> select that venue.</li>
                     <li>
-                        If several fields are available at a venue that can be used simultaneously,
+                        If several fields are available at a venue that can be used <strong>simultaneously</strong>,
                         a separate venue should be created for each field, and assigned to the using team.
                     </li>
                 </ul>

--- a/League/Views/TeamApplication/Start.de.cshtml
+++ b/League/Views/TeamApplication/Start.de.cshtml
@@ -19,7 +19,7 @@
         <div class="col-12">
             <h4 class="h4">Wer kann anmelden</h4>
             <p>
-                Berechtigte Mitglieder der Teams können ihr Team sehr einfach für die nächste Saison anmelden.
+                Teamkontakte können ihr Team sehr einfach für die nächste Saison anmelden.
                 Das gilt für alle Teams die jemals an einer Saison teilgenommen haben.
             </p>
             <p>
@@ -30,17 +30,17 @@
                 Folgende Angaben werden abgefragt und sollten daher zur Hand sein:
                 <ul>
                     <li>Teamname</li>
-                    <li>Names des Vereins (sofern zutreffend)</li>
+                    <li>Name des Vereins (sofern zutreffend)</li>
                     <li>Wochentag und Uhrzeit der Heimspiele</li>
-                    <li>Name und genau Anschrift des Spielorts</li>
+                    <li>Name und genaue Anschrift des Spielorts</li>
                 </ul>
             </p>
             <h4 class="h4">Spielort</h4>
             <p>
-                Damit die Spieltag automatisch und ohne Überschneidungen ermittelt werden können,
+                Damit die Spieltage automatisch und ohne Überschneidungen ermittelt werden können,
                 bitte folgendes beachten:
                 <ul>
-                    <li>Alle Teams, die ein Feld eines Spielort zeitgleich nutzen, müssen diesen auswählen.</li>
+                    <li>Alle Teams, die ein Feld eines Spielort zeitgleich nutzen, <strong>müssen</strong> diesen auswählen.</li>
                     <li>
                         Wenn an einem Spielort mehrere Felder zur Verfügung stehen, die <strong>zeitgleich</strong> genutzt werden können,
                         soll für jedes Spielfeld ein eigener Spielort angelegt und dem nutzenden Team zuordnet werden.
@@ -55,8 +55,8 @@
                 </li>
                 <li>Die Teamkontakte werden den Mitgliedern anderer Teams angezeigt (und nur diesen).</li>
                 <li>
-                    Zusätzlich zu den Teamkontakten können jedem Team SpielerInnen zugeordnet werden.
-                    Die Kontaktdaten der SpielerInnen sind nur den Teamkollegen zugänglich.
+                    Zusätzlich zu den Teamkontakten können jedem Team Spielerinnen bzw. Spieler zugeordnet werden.
+                    Die Kontaktdaten der Spielerinnen bzw. Spielern sind nur den Teamkollegen zugänglich.
                 </li>
             </ul>
         </div>

--- a/TournamentManager/TournamentManager.Tests/ModelValidators/TeamVenueValidatorTests.cs
+++ b/TournamentManager/TournamentManager.Tests/ModelValidators/TeamVenueValidatorTests.cs
@@ -1,0 +1,94 @@
+﻿using NUnit.Framework;
+using TournamentManager.DAL.EntityClasses;
+using TournamentManager.ModelValidators;
+using Moq;
+using TournamentManager.Data;
+using TournamentManager.MultiTenancy;
+using TournamentManager.Tests.TestComponents;
+using TeamRules = TournamentManager.MultiTenancy.TeamRules;
+
+namespace TournamentManager.Tests.ModelValidators;
+
+[TestFixture]
+public class TeamVenueValidatorTests
+{
+    private readonly ITenantContext _tenantContext;
+#pragma warning disable IDE0052 // Remove unread private members
+    private readonly AppDb _appDb; // mocked in CTOR
+#pragma warning restore IDE0052 // Remove unread private members
+
+    public TeamVenueValidatorTests()
+    {
+        #region *** Mocks ***
+
+        var tenantContextMock = TestMocks.GetTenantContextMock();
+        var appDbMock = TestMocks.GetAppDbMock();
+
+        var teamRepoMock = TestMocks.GetRepo<TeamRepository>();
+        teamRepoMock
+            .Setup(rep => rep.TeamNameExistsAsync(It.IsAny<TeamEntity>(), It.IsAny<CancellationToken>()))
+            .Callback(() => { }).Returns((TeamEntity teamEntity, CancellationToken cancellationToken) =>
+            {
+                return Task.FromResult(teamEntity.Id < 10 ? teamEntity.Name : null);
+            });
+
+        var venueRepoMock = TestMocks.GetRepo<VenueRepository>();
+        venueRepoMock
+            .Setup(rep => rep.IsValidVenueIdAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .Callback(() => { }).Returns((long? theValue, CancellationToken cancellationToken) =>
+            {
+                return Task.FromResult(theValue is < 10);
+            });
+
+        appDbMock.Setup(a => a.TeamRepository).Returns(teamRepoMock.Object);
+        appDbMock.Setup(a => a.VenueRepository).Returns(venueRepoMock.Object);
+
+        var dbContextMock = TestMocks.GetDbContextMock();
+        dbContextMock.SetupAppDb(appDbMock);
+            
+        tenantContextMock.SetupDbContext(dbContextMock);
+            
+        _tenantContext = tenantContextMock.Object;
+
+        _appDb = appDbMock.Object;
+
+        #endregion
+    }
+
+    [TestCase(null, true, false)]
+    [TestCase(1, true, true)]
+    [TestCase(null, false, true)]
+    [TestCase(1, false, true)]
+    public async Task Venue_Is_Set_If_Required(long? venueId, bool mustBeSet, bool expected)
+    {
+        var team = new TeamEntity { VenueId = venueId };
+
+        _tenantContext.TournamentContext.TeamRuleSet = new TeamRules {
+            HomeVenue = new HomeVenue { MustBeSet = mustBeSet }
+        };
+        var tv = new TeamVenueValidator(team, _tenantContext);
+
+        var factResult = await tv.CheckAsync(TeamVenueValidator.FactId.VenueIsSetIfRequired, CancellationToken.None);
+
+        Assert.IsNull(factResult.Exception);
+        Assert.That(factResult.Success, Is.EqualTo(expected));
+    }
+
+    [TestCase(1, true)]
+    [TestCase(100, false)] // above 10 is invalid
+    [TestCase(null, false)] // null is invalid
+    public async Task Team_VenueId_Is_Valid(long? venueId, bool expected)
+    {
+        var team = new TeamEntity { VenueId = venueId };
+
+        _tenantContext.TournamentContext.TeamRuleSet = new TeamRules {
+            HomeVenue = new HomeVenue { MustBeSet = false }
+        };
+        var tv = new TeamVenueValidator(team, _tenantContext);
+
+        var factResult = await tv.CheckAsync(TeamVenueValidator.FactId.VenueIsValid, CancellationToken.None);
+
+        Assert.IsNull(factResult.Exception);
+        Assert.That(factResult.Success, Is.EqualTo(expected));
+    }
+}

--- a/TournamentManager/TournamentManager/ModelValidators/AbstractValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/AbstractValidator.cs
@@ -221,7 +221,7 @@ public abstract class AbstractValidator<TModel, TData, TFactId>
             await CheckAsync(fact.Id, cancellationToken);
         }
         // stop after any not successful critical facts
-        if (facts.Any(f => f.IsChecked && !f.Success)) return facts;
+        if (facts.Any(f => f is { IsChecked: true, Success: false })) return facts;
 
         // next process error facts
         facts = GetFactsOfType(FactType.Error).ToList();

--- a/TournamentManager/TournamentManager/ModelValidators/TeamValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/TeamValidator.cs
@@ -62,14 +62,15 @@ public class TeamValidator : AbstractValidator<TeamEntity, ITenantContext, TeamV
             {
                 Id = FactId.MatchDayOfWeekAndTimeIsSet,
                 FieldNames = new[] {nameof(Model.MatchDayOfWeek), nameof(Model.MatchTime)},
-                Enabled = Data.TournamentContext.TeamRuleSet.HomeMatchTime.IsEditable && Data.TournamentContext.TeamRuleSet.HomeMatchTime.MustBeSet,
+                Enabled = Data.TournamentContext.TeamRuleSet.HomeMatchTime is { IsEditable: true },
                 Type = FactType.Critical,
                 CheckAsync = (cancellationToken) => Task.FromResult(
                     new FactResult
                     {
                         Message = TeamValidatorResource.ResourceManager.GetString(
                             nameof(FactId.MatchDayOfWeekAndTimeIsSet)) ?? string.Empty,
-                        Success = Model.MatchDayOfWeek.HasValue && Model.MatchTime.HasValue
+                        Success = (Data.TournamentContext.TeamRuleSet.HomeMatchTime.MustBeSet && Model is { MatchDayOfWeek: not null, MatchTime: not null })
+                            || (!Data.TournamentContext.TeamRuleSet.HomeMatchTime.MustBeSet && Model is { MatchDayOfWeek: null, MatchTime: null } or { MatchDayOfWeek: not null, MatchTime: not null })
                     })
             });
 
@@ -78,7 +79,7 @@ public class TeamValidator : AbstractValidator<TeamEntity, ITenantContext, TeamV
             {
                 Id = FactId.DayOfWeekWithinRange,
                 FieldNames = new[] {nameof(Model.MatchDayOfWeek)},
-                Enabled = Data.TournamentContext.TeamRuleSet.HomeMatchTime.IsEditable && Data.TournamentContext.TeamRuleSet.HomeMatchTime.MustBeSet,
+                Enabled = Data.TournamentContext.TeamRuleSet.HomeMatchTime is { IsEditable: true, MustBeSet: true },
                 Type = Data.TournamentContext.TeamRuleSet.HomeMatchTime.ErrorIfNotInDaysOfWeekRange
                     ? FactType.Error
                     : FactType.Warning,

--- a/TournamentManager/TournamentManager/ModelValidators/TeamVenueValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/TeamVenueValidator.cs
@@ -1,0 +1,55 @@
+﻿using TournamentManager.DAL.EntityClasses;
+using TournamentManager.MultiTenancy;
+
+namespace TournamentManager.ModelValidators;
+
+public class TeamVenueValidator : AbstractValidator<TeamEntity, ITenantContext, TeamVenueValidator.FactId>
+{
+    public enum FactId
+    {
+        VenueIsSetIfRequired,
+        VenueIsValid
+    }
+
+    public TeamVenueValidator(TeamEntity model, ITenantContext tenantContext) : base(model, tenantContext)
+    {
+        CreateFacts();
+    }
+
+    private void CreateFacts()
+    {
+        Facts.Add(
+            new Fact<FactId>
+            {
+                Id = FactId.VenueIsSetIfRequired,
+                FieldNames = new[] {nameof(Model.VenueId)},
+                Enabled = true,
+                Type = FactType.Critical,
+                CheckAsync = (cancellationToken) => Task.FromResult(
+                    new FactResult
+                    {
+                        Message = TeamVenueValidatorResource.ResourceManager.GetString(
+                                nameof(FactId.VenueIsSetIfRequired)) ?? string.Empty,
+                        // Venue is set, if required or venue has any value if not required
+                        Success = (Model.VenueId.HasValue && Data.TournamentContext.TeamRuleSet.HomeVenue.MustBeSet)
+                            || (!Data.TournamentContext.TeamRuleSet.HomeVenue.MustBeSet)
+                    })
+            });
+
+        Facts.Add(
+            new Fact<FactId>
+            {
+                Id = FactId.VenueIsValid,
+                FieldNames = new[] {nameof(Model.VenueId)},
+                Enabled = Model.VenueId.HasValue,
+                Type = FactType.Critical,
+                CheckAsync = async (cancellationToken) => new FactResult {
+                    Message = TeamVenueValidatorResource.ResourceManager.GetString(
+                            nameof(FactId.VenueIsValid)) ?? string.Empty,
+                    Success = Model.VenueId.HasValue &&
+                              await Data.DbContext.AppDb.VenueRepository.IsValidVenueIdAsync(Model.VenueId,
+                                  cancellationToken)
+                }
+            });
+    }
+}

--- a/TournamentManager/TournamentManager/ModelValidators/TeamVenueValidatorResource.Designer.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/TeamVenueValidatorResource.Designer.cs
@@ -22,24 +22,24 @@ namespace TournamentManager.ModelValidators {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    public class TeamValidatorResource {
+    internal class TeamVenueValidatorResource {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal TeamValidatorResource() {
+        internal TeamVenueValidatorResource() {
         }
         
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        public static global::System.Resources.ResourceManager ResourceManager {
+        internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("TournamentManager.ModelValidators.TeamValidatorResource", typeof(TeamValidatorResource).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("TournamentManager.ModelValidators.TeamVenueValidatorResource", typeof(TeamVenueValidatorResource).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -51,7 +51,7 @@ namespace TournamentManager.ModelValidators {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        public static global::System.Globalization.CultureInfo Culture {
+        internal static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -61,65 +61,20 @@ namespace TournamentManager.ModelValidators {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Day of week is outside {0} range.
+        ///   Looks up a localized string similar to The team is not assigned a venue.
         /// </summary>
-        public static string DayOfWeekWithinRange {
+        internal static string VenueIsSetIfRequired {
             get {
-                return ResourceManager.GetString("DayOfWeekWithinRange", resourceCulture);
+                return ResourceManager.GetString("VenueIsSetIfRequired", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Day of week and time for home matches must be set.
+        ///   Looks up a localized string similar to The venue does not exist or is invalid.
         /// </summary>
-        public static string MatchDayOfWeekAndTimeIsSet {
+        internal static string VenueIsValid {
             get {
-                return ResourceManager.GetString("MatchDayOfWeekAndTimeIsSet", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Start time is outside the range from {0} to {1}.
-        /// </summary>
-        public static string MatchTimeWithinRange {
-            get {
-                return ResourceManager.GetString("MatchTimeWithinRange", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to recommended.
-        /// </summary>
-        public static string recommended {
-            get {
-                return ResourceManager.GetString("recommended", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to required.
-        /// </summary>
-        public static string required {
-            get {
-                return ResourceManager.GetString("required", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Team name must not be empty.
-        /// </summary>
-        public static string TeamNameIsSet {
-            get {
-                return ResourceManager.GetString("TeamNameIsSet", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The team name &apos;{0}&apos; is already assigned.
-        /// </summary>
-        public static string TeamNameIsUnique {
-            get {
-                return ResourceManager.GetString("TeamNameIsUnique", resourceCulture);
+                return ResourceManager.GetString("VenueIsValid", resourceCulture);
             }
         }
     }

--- a/TournamentManager/TournamentManager/ModelValidators/TeamVenueValidatorResource.de.resx
+++ b/TournamentManager/TournamentManager/ModelValidators/TeamVenueValidatorResource.de.resx
@@ -117,43 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="MemberAddFailure" xml:space="preserve">
-    <value>Adding the team member failed</value>
+  <data name="VenueIsSetIfRequired" xml:space="preserve">
+    <value>Dem Team ist kein Spielort zugeordnet</value>
   </data>
-  <data name="MemberAddSuccess" xml:space="preserve">
-    <value>Team member has been added</value>
-  </data>
-  <data name="MemberCannotRemoveLastTeamManager" xml:space="preserve">
-    <value>The last team contact cannot be removed. Please assign another team contact before.</value>
-  </data>
-  <data name="MemberRemoveFailure" xml:space="preserve">
-    <value>Removing the team member failed</value>
-  </data>
-  <data name="MemberRemoveSuccess" xml:space="preserve">
-    <value>Team member has been removed</value>
-  </data>
-  <data name="TeamDataFailure" xml:space="preserve">
-    <value>Update of team data has failed</value>
-  </data>
-  <data name="TeamDataSuccess" xml:space="preserve">
-    <value>Team data have been updated successfully</value>
-  </data>
-  <data name="VenueCreateFailure" xml:space="preserve">
-    <value>Creating a new venue for the team failed</value>
-  </data>
-  <data name="VenueCreateSuccess" xml:space="preserve">
-    <value>A new venue has been created for the team</value>
-  </data>
-  <data name="VenueEditFailure" xml:space="preserve">
-    <value>Update of team venue data has failed</value>
-  </data>
-  <data name="VenueEditSuccess" xml:space="preserve">
-    <value>Team venue data have been updated sucessfully</value>
-  </data>
-  <data name="VenueSelectFailure" xml:space="preserve">
-    <value>Changing the selected team venue has failed</value>
-  </data>
-  <data name="VenueSelectSuccess" xml:space="preserve">
-    <value>The selected team venue has been changed successfully</value>
+  <data name="VenueIsValid" xml:space="preserve">
+    <value>Der Spielort existiert nicht oder ist ungültig</value>
   </data>
 </root>

--- a/TournamentManager/TournamentManager/ModelValidators/TeamVenueValidatorResource.resx
+++ b/TournamentManager/TournamentManager/ModelValidators/TeamVenueValidatorResource.resx
@@ -117,43 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="MemberAddFailure" xml:space="preserve">
-    <value>Adding the team member failed</value>
+  <data name="VenueIsSetIfRequired" xml:space="preserve">
+    <value>The team is not assigned a venue</value>
   </data>
-  <data name="MemberAddSuccess" xml:space="preserve">
-    <value>Team member has been added</value>
-  </data>
-  <data name="MemberCannotRemoveLastTeamManager" xml:space="preserve">
-    <value>The last team contact cannot be removed. Please assign another team contact before.</value>
-  </data>
-  <data name="MemberRemoveFailure" xml:space="preserve">
-    <value>Removing the team member failed</value>
-  </data>
-  <data name="MemberRemoveSuccess" xml:space="preserve">
-    <value>Team member has been removed</value>
-  </data>
-  <data name="TeamDataFailure" xml:space="preserve">
-    <value>Update of team data has failed</value>
-  </data>
-  <data name="TeamDataSuccess" xml:space="preserve">
-    <value>Team data have been updated successfully</value>
-  </data>
-  <data name="VenueCreateFailure" xml:space="preserve">
-    <value>Creating a new venue for the team failed</value>
-  </data>
-  <data name="VenueCreateSuccess" xml:space="preserve">
-    <value>A new venue has been created for the team</value>
-  </data>
-  <data name="VenueEditFailure" xml:space="preserve">
-    <value>Update of team venue data has failed</value>
-  </data>
-  <data name="VenueEditSuccess" xml:space="preserve">
-    <value>Team venue data have been updated sucessfully</value>
-  </data>
-  <data name="VenueSelectFailure" xml:space="preserve">
-    <value>Changing the selected team venue has failed</value>
-  </data>
-  <data name="VenueSelectSuccess" xml:space="preserve">
-    <value>The selected team venue has been changed successfully</value>
+  <data name="VenueIsValid" xml:space="preserve">
+    <value>The venue does not exist or is invalid</value>
   </data>
 </root>

--- a/TournamentManager/TournamentManager/TournamentManager.csproj
+++ b/TournamentManager/TournamentManager/TournamentManager.csproj
@@ -95,6 +95,11 @@ Volleyball League is an open source sports platform that brings everything neces
             <AutoGen>True</AutoGen>
             <DependentUpon>TeamValidatorResource.resx</DependentUpon>
         </Compile>
+        <Compile Update="ModelValidators\TeamVenueValidatorResource.Designer.cs">
+          <DesignTime>True</DesignTime>
+          <AutoGen>True</AutoGen>
+          <DependentUpon>TeamVenueValidatorResource.resx</DependentUpon>
+        </Compile>
         <Compile Update="ModelValidators\VenueValidatorResource.Designer.cs">
             <DesignTime>True</DesignTime>
             <AutoGen>True</AutoGen>
@@ -134,6 +139,10 @@ Volleyball League is an open source sports platform that brings everything neces
         <EmbeddedResource Update="ModelValidators\TeamInRoundValidatorResource.resx">
             <LastGenOutput>TeamInRoundValidatorResource.Designer.cs</LastGenOutput>
             <Generator>ResXFileCodeGenerator</Generator>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ModelValidators\TeamVenueValidatorResource.resx">
+          <Generator>ResXFileCodeGenerator</Generator>
+          <LastGenOutput>TeamVenueValidatorResource.Designer.cs</LastGenOutput>
         </EmbeddedResource>
         <EmbeddedResource Update="ModelValidators\VenueValidatorResource.resx">
             <LastGenOutput>VenueValidatorResource.Designer.cs</LastGenOutput>


### PR DESCRIPTION
#### `Team.SelectVenue`, `TeamApplication.SelectVenue`
* Change `Not found` response to JsonResponseRedirect
* Change display message from TeamDataFailure to VenueSelectFailure

#### `TeamApplication`
* Call `SignInManager.RefreshSignInAsync()` after a user has registered a new team, so that it`s immediately visible in `Team.MyTeam`
* Enable null for team venue and home match day/time
  * Add `ApplicationSessionModel.TeamVenueSetKind` to track "not set, no venue, existing venue, new venue"
  * Add `TeamVenueValidator` to validate selected venue types

#### `TeamEditor` component
* Add `readonly` attribute to HTML element instead of `disabled` for `null` value

#### `VenueSelector` component
* Add `Criteria.NotSpecified` if this is allowed in tenant specific `TournamentContext`
* Include `Criteria.NotSpecified` to selectable venue options

#### `Team.MyTeam`, `Team.Single` views
* Update display for venue, match day/time