### PR TITLE
Update NPM packages

### DIFF
--- a/League/Styles/site/site.scss
+++ b/League/Styles/site/site.scss
@@ -184,3 +184,7 @@ fieldset legend {
     max-width: $body-width - 2;
     margin: 2.5rem auto;
 }
+
+.text-muted { // Has been depreciated in Bootstrap 5.3.0, will be replaced by .text-body-secondary in v6
+    color: var(--bs-gray-600) !important;
+}

--- a/League/package-lock.json
+++ b/League/package-lock.json
@@ -11,16 +11,16 @@
         "uglify-js": "3.17.4"
       },
       "devDependencies": {
-        "@eonasdan/tempus-dominus": "6.7.11",
-        "@fortawesome/fontawesome-free": "5.13.0",
-        "@popperjs/core": "2.11.7",
+        "@eonasdan/tempus-dominus": "6.7.13",
+        "@fortawesome/fontawesome-free": "5.13.1",
+        "@popperjs/core": "2.11.8",
         "autoprefixer": "9.8.8",
-        "bootstrap": "5.3.0",
+        "bootstrap": "5.3.1",
         "cssnano": "4.1.11",
         "dropzone": "5.7.1",
         "grunt": "1.6.1",
         "grunt-cli": "1.4.3",
-        "grunt-contrib-concat": "1.0.1",
+        "grunt-contrib-concat": "2.1.0",
         "grunt-contrib-copy": "1.0.0",
         "grunt-contrib-uglify": "5.2.2",
         "grunt-contrib-watch": "1.1.0",
@@ -28,9 +28,9 @@
         "grunt-sass": "3.1.0",
         "js-cookie": "2.2.1",
         "jsnlog": "2.30.0",
-        "node-sass": "8.0.0",
+        "node-sass": "9.0.0",
         "pixrem": "5.0.0",
-        "set-value": ">=4.0.1"
+        "set-value": ">=4.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@eonasdan/tempus-dominus": {
-      "version": "6.7.11",
-      "resolved": "https://registry.npmjs.org/@eonasdan/tempus-dominus/-/tempus-dominus-6.7.11.tgz",
-      "integrity": "sha512-RgnCNsnxLgbVtCKKTXYDB4fpr6dX6tVD9drKScU5THdSbQ/yfqsbpkO8XFUoeWWrgr1HpgD83Whd3cAci7KXFw==",
+      "version": "6.7.13",
+      "resolved": "https://registry.npmjs.org/@eonasdan/tempus-dominus/-/tempus-dominus-6.7.13.tgz",
+      "integrity": "sha512-1saI7S0WM6jVE+799KjwsVwcDgrde4SUwmR9AofWGi+yq6w4j6TfVCF9rss+pMXTjSnApY17Nd70260pdm3LTA==",
       "dev": true,
       "funding": {
         "url": "https://ko-fi.com/eonasdan"
@@ -86,9 +86,9 @@
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.13.0.tgz",
-      "integrity": "sha512-xKOeQEl5O47GPZYIMToj6uuA2syyFlq9EMSl2ui0uytjY9xbe8XS0pexNWmxrdcCyNGyDmLyYw5FtKsalBUeOg==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.13.1.tgz",
+      "integrity": "sha512-D819f34FLHeBN/4xvw0HR0u7U2G7RqjPSggXqf7LktsxWQ48VAfGwvMrhcVuaZV2fF069c/619RdgCCms0DHhw==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
-      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -406,9 +406,9 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.0.tgz",
-      "integrity": "sha512-UnBV3E3v4STVNQdms6jSGO2CvOkjUMdDAVR2V5N4uCMdaIkaQjbcEAMqRimDHIs4uqBYzDAKCQwCB+97tJgHQw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.1.tgz",
+      "integrity": "sha512-jzwza3Yagduci2x0rr9MeFSORjcHpt0lRZukZPZQJT1Dth5qzV7XcgGqYzi39KGAVYR8QEDVoO0ubFKOxzMG+g==",
       "dev": true,
       "funding": [
         {
@@ -421,7 +421,7 @@
         }
       ],
       "peerDependencies": {
-        "@popperjs/core": "^2.11.7"
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/brace-expansion": {
@@ -1867,74 +1867,89 @@
       }
     },
     "node_modules/grunt-contrib-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-1.0.1.tgz",
-      "integrity": "sha512-QdTmcxe8aim2Z0dFeuSJ+f7fHIeY7PZaTMZxgvosjXwyMhpy2GUR5WHkr12lksHfZVE80v2wUwqF56wyfPUwoQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-2.1.0.tgz",
+      "integrity": "sha512-Vnl95JIOxfhEN7bnYIlCgQz41kkbi7tsZ/9a4usZmxNxi1S2YAIOy8ysFmO8u4MN26Apal1O106BwARdaNxXQw==",
       "dev": true,
       "dependencies": {
-        "chalk": "^1.0.0",
+        "chalk": "^4.1.2",
         "source-map": "^0.5.3"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=0.12.0"
       },
       "peerDependencies": {
-        "grunt": ">=0.4.0"
-      }
-    },
-    "node_modules/grunt-contrib-concat/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
+        "grunt": ">=1.4.1"
       }
     },
     "node_modules/grunt-contrib-concat/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/grunt-contrib-concat/node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/grunt-contrib-concat/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+    "node_modules/grunt-contrib-concat/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^2.0.0"
+        "color-name": "~1.1.4"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/grunt-contrib-concat/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/grunt-contrib-concat/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/grunt-contrib-concat/node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=8"
       }
     },
     "node_modules/grunt-contrib-copy": {
@@ -3749,9 +3764,9 @@
       "dev": true
     },
     "node_modules/node-sass": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-8.0.0.tgz",
-      "integrity": "sha512-jPzqCF2/e6JXw6r3VxfIqYc8tKQdkj5Z/BDATYyG6FL6b/LuYBNFGFVhus0mthcWifHm/JzBpKAd+3eXsWeK/A==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-9.0.0.tgz",
+      "integrity": "sha512-yltEuuLrfH6M7Pq2gAj5B6Zm7m+gdZoG66wTqG6mIZV/zijq3M2OO2HswtT6oBspPyFhHDcaxWpsBm0fRNDHPg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3774,7 +3789,7 @@
         "node-sass": "bin/node-sass"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/node-sass/node_modules/ansi-styles": {
@@ -6231,16 +6246,16 @@
       }
     },
     "@eonasdan/tempus-dominus": {
-      "version": "6.7.11",
-      "resolved": "https://registry.npmjs.org/@eonasdan/tempus-dominus/-/tempus-dominus-6.7.11.tgz",
-      "integrity": "sha512-RgnCNsnxLgbVtCKKTXYDB4fpr6dX6tVD9drKScU5THdSbQ/yfqsbpkO8XFUoeWWrgr1HpgD83Whd3cAci7KXFw==",
+      "version": "6.7.13",
+      "resolved": "https://registry.npmjs.org/@eonasdan/tempus-dominus/-/tempus-dominus-6.7.13.tgz",
+      "integrity": "sha512-1saI7S0WM6jVE+799KjwsVwcDgrde4SUwmR9AofWGi+yq6w4j6TfVCF9rss+pMXTjSnApY17Nd70260pdm3LTA==",
       "dev": true,
       "requires": {}
     },
     "@fortawesome/fontawesome-free": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.13.0.tgz",
-      "integrity": "sha512-xKOeQEl5O47GPZYIMToj6uuA2syyFlq9EMSl2ui0uytjY9xbe8XS0pexNWmxrdcCyNGyDmLyYw5FtKsalBUeOg==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.13.1.tgz",
+      "integrity": "sha512-D819f34FLHeBN/4xvw0HR0u7U2G7RqjPSggXqf7LktsxWQ48VAfGwvMrhcVuaZV2fF069c/619RdgCCms0DHhw==",
       "dev": true
     },
     "@gar/promisify": {
@@ -6270,9 +6285,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
-      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "dev": true
     },
     "@tootallnate/once": {
@@ -6491,9 +6506,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.0.tgz",
-      "integrity": "sha512-UnBV3E3v4STVNQdms6jSGO2CvOkjUMdDAVR2V5N4uCMdaIkaQjbcEAMqRimDHIs4uqBYzDAKCQwCB+97tJgHQw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.1.tgz",
+      "integrity": "sha512-jzwza3Yagduci2x0rr9MeFSORjcHpt0lRZukZPZQJT1Dth5qzV7XcgGqYzi39KGAVYR8QEDVoO0ubFKOxzMG+g==",
       "dev": true,
       "requires": {}
     },
@@ -7615,54 +7630,63 @@
       }
     },
     "grunt-contrib-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-1.0.1.tgz",
-      "integrity": "sha512-QdTmcxe8aim2Z0dFeuSJ+f7fHIeY7PZaTMZxgvosjXwyMhpy2GUR5WHkr12lksHfZVE80v2wUwqF56wyfPUwoQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-2.1.0.tgz",
+      "integrity": "sha512-Vnl95JIOxfhEN7bnYIlCgQz41kkbi7tsZ/9a4usZmxNxi1S2YAIOy8ysFmO8u4MN26Apal1O106BwARdaNxXQw==",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
+        "chalk": "^4.1.2",
         "source-map": "^0.5.3"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-          "dev": true
-        },
         "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-          "dev": true
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
         },
         "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "color-name": "~1.1.4"
           }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-          "dev": true
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
@@ -9059,9 +9083,9 @@
       "dev": true
     },
     "node-sass": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-8.0.0.tgz",
-      "integrity": "sha512-jPzqCF2/e6JXw6r3VxfIqYc8tKQdkj5Z/BDATYyG6FL6b/LuYBNFGFVhus0mthcWifHm/JzBpKAd+3eXsWeK/A==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-9.0.0.tgz",
+      "integrity": "sha512-yltEuuLrfH6M7Pq2gAj5B6Zm7m+gdZoG66wTqG6mIZV/zijq3M2OO2HswtT6oBspPyFhHDcaxWpsBm0fRNDHPg==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",

--- a/League/package.json
+++ b/League/package.json
@@ -8,14 +8,14 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
     "devDependencies": {
-        "@fortawesome/fontawesome-free": "5.13.0",
+        "@fortawesome/fontawesome-free": "5.13.1",
         "autoprefixer": "9.8.8",
-        "bootstrap": "5.3.0",
+        "bootstrap": "5.3.1",
         "cssnano": "4.1.11",
         "dropzone": "5.7.1",
         "grunt": "1.6.1",
         "grunt-cli": "1.4.3",
-        "grunt-contrib-concat": "1.0.1",
+        "grunt-contrib-concat": "2.1.0",
         "grunt-contrib-copy": "1.0.0",
         "grunt-contrib-uglify": "5.2.2",
         "grunt-contrib-watch": "1.1.0",
@@ -23,11 +23,11 @@
         "grunt-sass": "3.1.0",
         "js-cookie": "2.2.1",
         "jsnlog": "2.30.0",
-        "node-sass": "8.0.0",
+        "node-sass": "9.0.0",
         "pixrem": "5.0.0",
-        "@popperjs/core": "2.11.7",
-        "@eonasdan/tempus-dominus": "6.7.11",
-        "set-value": ">=4.0.1"
+        "@popperjs/core": "2.11.8",
+        "@eonasdan/tempus-dominus": "6.7.13",
+        "set-value": ">=4.1.0"
     },
     "dependencies": {
         "uglify-js": "3.17.4"


### PR DESCRIPTION
* node-sass: 9.0.0
* grunt-contrib-concat: 2.1.0
* @fortawesome/fontawesome-free: 5.13.1
* bootstrap: 5.3.1
* @popperjs/core: 2.11.8
* @eonasdan/tempus-dominus: 6.7.13
* set-value: >=4.1.0

Add css class `.text-muted` to site.scss
(has been depreciated in Bootstrap 5.3.0, will be replaced by .text-body-secondary in v6)