### PR TITLE
Add extension methods for RoundLegEntity and lists of RoundLegEntity

### DIFF
--- a/League.Demo/Views/Shared/_Layout.cshtml
+++ b/League.Demo/Views/Shared/_Layout.cshtml
@@ -6,7 +6,7 @@
 @inject ITenantContext TenantContext
 @inject IViewLocalizer Localizer
 <!DOCTYPE html>
-<html lang="@Thread.CurrentThread.CurrentUICulture.TwoLetterISOLanguageName">
+<html lang="@System.Threading.Thread.CurrentThread.CurrentUICulture.TwoLetterISOLanguageName">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=0" />

--- a/League/Views/Match/ReportSheet.cshtml
+++ b/League/Views/Match/ReportSheet.cshtml
@@ -1,16 +1,18 @@
 ﻿@using TournamentManager.MultiTenancy
+@using TournamentManager.DAL.EntityClasses
 @inject ITenantContext TenantContext
 @inject Axuno.Tools.DateAndTime.TimeZoneConverter TimeZoneConverter
 @inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer localizer
 @model TournamentManager.DAL.TypedViewClasses.MatchReportSheetRow
 @{
     Layout = null;
+    var numberOfSets = Model.BestOf ? Model.NumOfSets * 2 - 1 : Model.NumOfSets;
 
     ViewData["Title"] = localizer["Match Report Sheet"].Value;
     var ballPointsToWin = new List<int>();
     if (Model.BestOf)
     {
-        for (var i = 0; i < Model.NumOfSets - 1; i++)
+        for (var i = 0; i < numberOfSets - 1; i++)
         {
             ballPointsToWin.Add(Model.NumOfPointsToWinRegular);
         }
@@ -18,13 +20,12 @@
     }
     else
     {
-        for (var i = 0; i < Model.NumOfSets; i++)
+        for (var i = 0; i < numberOfSets; i++)
         {
             ballPointsToWin.Add(Model.NumOfPointsToWinRegular);
         }
     }
 
-    var numberOfSets = ballPointsToWin.Count;
     var numOfSubstitutions = Model.MaxSubstitutions;
     var numOfTimeOuts = Model.MaxTimeouts;
     var bsRowCol = string.Empty;
@@ -168,10 +169,24 @@
         .team-circle {
             background: #ffffff;
             color: #000;
-            padding: 5px 20px;
+            /*padding: 5px 20px;*/
             border-radius: 50%;
             border: 1px solid black;
-            font-size: 35px;
+            /*font-size: 35px;*/
+            width: 30px;
+            height: 30px;
+            display: inline-block;
+        }
+
+        .team-circle-small {
+            background: #ffffff;
+            color: #000;
+            padding: 0px 5px;
+            border-radius: 50%;
+            border: 1px solid black;
+            font-size: 12pt;
+            margin-left: 5px;
+            margin-right: 5px;
         }
 
         .border {
@@ -208,17 +223,6 @@
 
         .border-left-0 {
             border-left: 0 !important
-        }
-
-        .team-circle-small {
-            background: #ffffff;
-            color: #000;
-            padding: 0px 5px;
-            border-radius: 50%;
-            border: 1px solid black;
-            font-size: 12pt;
-            margin-left: 5px;
-            margin-right: 5px;
         }
 
         .dotted-line {
@@ -315,10 +319,10 @@
                         <div class="text-start">@localizer["Results"]</div><div class="text-end">@localizer["Team"]</div>
                     </div>
                     <div class="col-4 text-center border pt-1 pb-1">
-                        <span class="team-circle">&nbsp;</span>
+                        <div class="team-circle">&nbsp;</div>
                     </div>
                     <div class="col-4 text-center border pt-1 pb-1">
-                        <span class="team-circle">&nbsp;</span>
+                        <div class="team-circle">&nbsp;</div>
                     </div>
 
                     @{
@@ -326,7 +330,7 @@
                         {
                             for (var i = 1; i <= numberOfSets; i++)
                             {
-                                <div class="col-4 border" style="line-height: 2rem">
+                                <div class="col-4 border" style="line-height: 1.75rem">
                                     @localizer["Set #{0}", i]
                                 </div>
                                 <div class="col-4 text-center border">
@@ -339,7 +343,7 @@
                         }
                     }
 
-                    <div class="col-4 border" style="line-height: 2rem">
+                    <div class="col-4 border" style="line-height: 1.75rem">
                         @localizer["Ball points"]
                     </div>
                     <div class="col-4 text-center border">
@@ -348,7 +352,7 @@
                     <div class="col-4 text-center border">
 
                     </div>
-                    <div class="col-4 border" style="line-height: 2rem">
+                    <div class="col-4 border" style="line-height: 1.75rem">
                         @localizer["Set points"]
                     </div>
                     <div class="col-4 text-center border">
@@ -357,7 +361,7 @@
                     <div class="col-4 text-center border">
 
                     </div>
-                    <div class="col-4 border" style="line-height: 2rem">
+                    <div class="col-4 border" style="line-height: 1.75rem">
                         @localizer["Match points"]
                     </div>
                     <div class="col-4 text-center border">

--- a/TournamentManager/TournamentManager.Tests/ModelValidators/SetsValidatorTests.cs
+++ b/TournamentManager/TournamentManager.Tests/ModelValidators/SetsValidatorTests.cs
@@ -67,7 +67,7 @@ public class SetsValidatorTests
         }
 
         var sv = new SetsValidator(sets, (new TenantContext(), (new MatchRuleEntity { BestOf = true, NumOfSets = 3 }, new SetRuleEntity())));
-        await sv.CheckAsync(SetsValidator.FactId.BestOfMixAndMaxOfSetsPlayed, CancellationToken.None);
+        await sv.CheckAsync(SetsValidator.FactId.BestOfMinAndMaxOfSetsPlayed, CancellationToken.None);
         Assert.Multiple(() =>
             {
                 if (shouldSucceed)
@@ -76,8 +76,8 @@ public class SetsValidatorTests
                 }
                 else
                 {
-                    Assert.IsFalse(sv.GetFailedFacts().First(f => f.Id == SetsValidator.FactId.BestOfMixAndMaxOfSetsPlayed).Success);
-                    Assert.IsNotNull(sv.GetFailedFacts().First(f => f.Id == SetsValidator.FactId.BestOfMixAndMaxOfSetsPlayed).Message);
+                    Assert.IsFalse(sv.GetFailedFacts().First(f => f.Id == SetsValidator.FactId.BestOfMinAndMaxOfSetsPlayed).Success);
+                    Assert.IsNotNull(sv.GetFailedFacts().First(f => f.Id == SetsValidator.FactId.BestOfMinAndMaxOfSetsPlayed).Message);
                 }
             }
         );

--- a/TournamentManager/TournamentManager/ExtensionMethods/RoundLegEntityExtensions.cs
+++ b/TournamentManager/TournamentManager/ExtensionMethods/RoundLegEntityExtensions.cs
@@ -1,0 +1,30 @@
+﻿using TournamentManager.DAL.EntityClasses;
+
+namespace TournamentManager.ExtensionMethods;
+
+/// <summary>
+/// <see cref="RoundLegEntity"/> extension methods.
+/// </summary>
+public static class RoundLegEntityExtensions
+{
+    /// <summary>
+    /// Checks whether the <param name="dateTime"></param> is between
+    /// <see cref="RoundLegEntity.StartDateTime"/> and <see cref="RoundLegEntity.EndDateTime"/>.
+    /// If one of the date values is <see langword="null"/>, <see langword="false"/> is returned.
+    /// </summary>
+    /// <param name="roundLeg"></param>
+    /// <param name="dateTime"></param>
+    /// <returns>Returns <see langword="true"/>, if the <param name="dateTime"></param> is between
+    /// <see cref="RoundLegEntity.StartDateTime"/> and <see cref="RoundLegEntity.EndDateTime"/>.
+    /// If one of the date values is <see langword="null"/>, <see langword="false"/> is returned.
+    /// </returns>
+    public static bool ContainsDate(this RoundLegEntity roundLeg, DateTime? dateTime)
+    {
+        if (roundLeg.StartDateTime.TimeOfDay.TotalMilliseconds == 0 && roundLeg.EndDateTime.TimeOfDay.TotalMilliseconds == 0)
+        {
+            return new DateTimePeriod(roundLeg.StartDateTime, roundLeg.EndDateTime.AddDays(1).AddMilliseconds(-1)).Contains(dateTime);
+        }
+
+        return new DateTimePeriod(roundLeg.StartDateTime, roundLeg.EndDateTime).Contains(dateTime);
+    }
+}

--- a/TournamentManager/TournamentManager/ExtensionMethods/RoundLegEntityListExtensions.cs
+++ b/TournamentManager/TournamentManager/ExtensionMethods/RoundLegEntityListExtensions.cs
@@ -1,0 +1,22 @@
+﻿using TournamentManager.DAL.EntityClasses;
+
+namespace TournamentManager.ExtensionMethods;
+
+/// <summary>
+/// <see cref="RoundLegEntity"/> <see cref="List{T}"/> extensions.
+/// </summary>
+public static class RoundLegEntityListExtensions
+{
+    /// <summary>
+    /// Gets the first <see cref="RoundLegEntity"/> in the <see cref="List{T}"/> that contains the <paramref name="dateTime"/>,
+    /// or <see langword="null"/> if none was found.
+    /// </summary>
+    /// <param name="roundLegList">The <see cref="IList{RoundLegEntity}"/> for which the calculation takes place.</param>
+    /// <param name="dateTime"></param>
+    /// <returns>Returns the first <see cref="RoundLegEntity"/> in the <see cref="List{T}"/> that contains the <paramref name="dateTime"/>,
+    /// or <see langword="null"/> if none was found.</returns>
+    public static RoundLegEntity? GetRoundLegForDate(this IList<RoundLegEntity> roundLegList, DateTime? dateTime)
+    {
+        return roundLegList.FirstOrDefault(roundLeg => roundLeg.ContainsDate(dateTime));
+    }
+}

--- a/TournamentManager/TournamentManager/ModelValidators/FixtureValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/FixtureValidator.cs
@@ -133,12 +133,9 @@ public class FixtureValidator : AbstractValidator<MatchEntity, (ITenantContext T
                     var currentLeg = round.RoundLegs.First(rl => rl.SequenceNo == Model.LegSequenceNo);
 
                     // Note: EndDateTime includes the full day
-                    if ((stayWithinLegDates &&
-                         new DateTimePeriod(currentLeg.StartDateTime, currentLeg.EndDateTime.AddDays(1).AddSeconds(-1)).Contains(
-                             Model.PlannedStart))
+                    if ((stayWithinLegDates && currentLeg.ContainsDate(Model.PlannedStart))
                         ||
-                        (!stayWithinLegDates && round.RoundLegs.Any(rl =>
-                            new DateTimePeriod(rl.StartDateTime, rl.EndDateTime.AddDays(1).AddSeconds(-1)).Contains(Model.PlannedStart))))
+                        (!stayWithinLegDates && round.RoundLegs.GetRoundLegForDate(Model.PlannedStart) != null))
                     {
                         return _successResult;
                     }
@@ -147,7 +144,7 @@ public class FixtureValidator : AbstractValidator<MatchEntity, (ITenantContext T
                     if (stayWithinLegDates)
                     {
                         displayPeriods =
-                            $"{currentLeg.StartDateTime.ToShortDateString()} - {currentLeg.StartDateTime.ToShortDateString()}";
+                            $"{currentLeg.StartDateTime.ToShortDateString()} - {currentLeg.EndDateTime.ToShortDateString()}";
                     }
                     else
                     {

--- a/TournamentManager/TournamentManager/ModelValidators/SetsValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/SetsValidator.cs
@@ -10,7 +10,7 @@ public class SetsValidator : AbstractValidator<IList<SetEntity>, (ITenantContext
     {
         AllSetsAreValid,
         MixAndMaxOfSetsPlayed,
-        BestOfMixAndMaxOfSetsPlayed,
+        BestOfMinAndMaxOfSetsPlayed,
         BestOfRequiredTieBreakPlayed,
         BestOfNoMatchAfterBestOfReached
     }
@@ -45,7 +45,7 @@ public class SetsValidator : AbstractValidator<IList<SetEntity>, (ITenantContext
         Facts.Add(
             new Fact<FactId>
             {
-                Id = FactId.BestOfMixAndMaxOfSetsPlayed,
+                Id = FactId.BestOfMinAndMaxOfSetsPlayed,
                 FieldNames = new[] { nameof(MatchEntity.Sets) },
                 Enabled = true,
                 Type = FactType.Critical,
@@ -54,7 +54,7 @@ public class SetsValidator : AbstractValidator<IList<SetEntity>, (ITenantContext
                     {
                         Message = string.Format(
                             SetsValidatorResource.ResourceManager.GetString(
-                                nameof(FactId.BestOfMixAndMaxOfSetsPlayed)) ?? string.Empty, Data.Rules.MatchRule.NumOfSets, Data.Rules.MatchRule.MaxNumOfSets()),
+                                nameof(FactId.BestOfMinAndMaxOfSetsPlayed)) ?? string.Empty, Data.Rules.MatchRule.NumOfSets, Data.Rules.MatchRule.MaxNumOfSets()),
                         Success = !Data.Rules.MatchRule.BestOf || Model.Count >= Data.Rules.MatchRule.NumOfSets && Model.Count <= Data.Rules.MatchRule.MaxNumOfSets()
                     })
             });


### PR DESCRIPTION
* Implement `RoundLegEntity` extensions in ModelValidators
* Match controller: `FixtureRuleSet.PlannedMatchTimeMustStayInCurrentLegBoundaries` is no more overridden by `TournamentEntity.IsPlanningMode`
* Stop team notifications for fixtures when `TournamentEntity.IsPlanningMode == true`
* Hotfix: ReportSheet.cshtml handels best-of matches correctly
* Hotfix in League.Demo: `using System.Threading` in _Layout.cshtml