### PR TITLE
Fix: Migrate WebApplicationBuilder.WebHost.ConfigureServices(...) for NET6+

### DIFF
--- a/League.Demo/WebAppStartup.cs
+++ b/League.Demo/WebAppStartup.cs
@@ -6,15 +6,18 @@ using Microsoft.Extensions.FileProviders;
 namespace League.WebApp;
 
 /// <summary>
-/// The demo startup class to setup and configure the league.
+/// The demo startup class to set up and configure the league.
 /// </summary>
 public static class WebAppStartup
 {
     /// <summary>
     /// The method gets called by <see cref="Program"/> at startup, BEFORE building the app is completed.
     /// </summary>
-    public static void ConfigureServices(WebHostBuilderContext context, IServiceCollection services, ILoggerFactory loggerFactory)
+    public static void ConfigureServices(WebApplicationBuilder builder, ILoggerFactory loggerFactory)
     {
+        var services = builder.Services;
+        var environment = builder.Environment;
+
         services.AddHttpsRedirection(options =>
         {
             options.RedirectStatusCode = Microsoft.AspNetCore.Http.StatusCodes.Status301MovedPermanently;
@@ -23,7 +26,7 @@ public static class WebAppStartup
         // Add custom navigation menu items to the League default navigation system
         services.AddScoped<IMainNavigationNodeBuilder, CustomMainNavigationNodeBuilder>();
 
-        if (context.HostingEnvironment.IsDevelopment())
+        if (environment.IsDevelopment())
         {
             // Add runtime compilation for the app
             services.AddRazorPages().AddRazorRuntimeCompilation();
@@ -31,7 +34,7 @@ public static class WebAppStartup
             services.Configure<MvcRazorRuntimeCompilationOptions>(options =>
             {
                 var leagueLibraryPath = Path.GetFullPath(
-                    Path.Combine(context.HostingEnvironment.ContentRootPath, "..", nameof(League)));
+                    Path.Combine(environment.ContentRootPath, "..", nameof(League)));
 
                 options.FileProviders.Add(new PhysicalFileProvider(leagueLibraryPath));
             });

--- a/League/LeagueStartup.cs
+++ b/League/LeagueStartup.cs
@@ -35,7 +35,7 @@ using League.TextTemplatingModule;
 namespace League;
 
 /// <summary>
-/// The startup class to setup and configure the the <see cref="League"/> Razor Class Library.
+/// The startup class to set up and configure the <see cref="League"/> Razor Class Library.
 /// Used in a derived class.
 /// </summary>
 public static class LeagueStartup
@@ -78,10 +78,11 @@ public static class LeagueStartup
     /// This method MUST be called from the derived class.
     /// It is used to add required <see cref="League"/> services to the service container.
     /// </summary>
-    public static void ConfigureServices(WebHostBuilderContext context, IServiceCollection services, ILoggerFactory loggerFactory)
+    public static void ConfigureServices(WebApplicationBuilder builder, ILoggerFactory loggerFactory)
     {
-        var configuration = context.Configuration;
-        var environment = context.HostingEnvironment;
+        var configuration = builder.Configuration;
+        var environment = builder.Environment;
+        var services = builder.Services;
 
         // Allow TournamentManager to make use of Microsoft.Extensions.Logging
         TournamentManager.AppLogging.Configure(loggerFactory);


### PR DESCRIPTION
Fixes #139

Reasoning: WebApplicationBuilder simplifies the process by directly exposing the Configuration and Environment properties, making it easier to work with configuration and services in .NET 6 and beyond.