### PR TITLE
Implement overruling match results

### DIFF
--- a/League/Authorization/MatchAuthorizationHandler.cs
+++ b/League/Authorization/MatchAuthorizationHandler.cs
@@ -7,7 +7,7 @@ public static class MatchOperations
 {
     public static readonly OperationAuthorizationRequirement ChangeFixture = new() { Name = nameof(ChangeFixture) };
     public static readonly OperationAuthorizationRequirement EnterResult = new() { Name = nameof(EnterResult) };
-    public static readonly OperationAuthorizationRequirement OverrideResult = new() { Name = nameof(OverrideResult) };
+    public static readonly OperationAuthorizationRequirement OverruleResult = new() { Name = nameof(OverruleResult) };
 }
 
 public class MatchAuthorizationHandler : AuthorizationHandler<OperationAuthorizationRequirement, MatchEntity>

--- a/League/Authorization/PolicyName.cs
+++ b/League/Authorization/PolicyName.cs
@@ -7,6 +7,10 @@ public static class PolicyName
     /// </summary>
     public const string MatchPolicy = nameof(MatchPolicy);
     /// <summary>
+    /// Policy for entering match results in overruling mode.
+    /// </summary>
+    public const string OverruleResultPolicy = nameof(OverruleResultPolicy);
+    /// <summary>
     /// Policy for seeing team contact data
     /// </summary>
     public const string SeeTeamContactsPolicy = nameof(SeeTeamContactsPolicy);

--- a/League/LeagueStartup.cs
+++ b/League/LeagueStartup.cs
@@ -304,6 +304,8 @@ public static class LeagueStartup
         {
             // Used on controller method level
             options.AddPolicy(Authorization.PolicyName.MatchPolicy, policy => policy.RequireRole(Identity.Constants.RoleName.SystemManager, Identity.Constants.RoleName.TournamentManager, Identity.Constants.RoleName.TeamManager));
+            // Used on controller method level
+            options.AddPolicy(Authorization.PolicyName.OverruleResultPolicy, policy => policy.RequireRole(Identity.Constants.RoleName.SystemManager, Identity.Constants.RoleName.TournamentManager, Identity.Constants.RoleName.TeamManager));
             // Used in team views
             options.AddPolicy(Authorization.PolicyName.SeeTeamContactsPolicy, policy => policy.RequireRole(Identity.Constants.RoleName.SystemManager, Identity.Constants.RoleName.TournamentManager, Identity.Constants.RoleName.TeamManager, Identity.Constants.RoleName.Player));
             // Used for my team views

--- a/League/Models/MatchViewModels/EnterResultViewModel.cs
+++ b/League/Models/MatchViewModels/EnterResultViewModel.cs
@@ -184,7 +184,7 @@ public class EnterResultViewModel
                 {
                     foreach (var setsError in validator.SetsValidator.GetFailedFacts())
                     {
-                        // This the the hint for existing errors in single sets
+                        // This is the hint for existing errors in single sets
                         if (setsError.Id == SetsValidator.FactId.AllSetsAreValid)
                         {
                             foreach (var singleSet in validator.SetsValidator.SingleSetErrors)

--- a/League/Styles/bootstrap/_custom_variables.scss
+++ b/League/Styles/bootstrap/_custom_variables.scss
@@ -26,7 +26,7 @@ $primary: #018DFF;
 $secondary: $gray-600;
 $success: #01DF02;
 $info: #015496;
-$warning: #FF8901;
+$warning: #FFA500; //#FFD700; //#FFA500; // #FF8901;
 $danger: #E401CD;
 $light: $gray-100;
 $dark: $gray-800;

--- a/League/TagHelpers/SiteValidationSummaryTagHelper.cs
+++ b/League/TagHelpers/SiteValidationSummaryTagHelper.cs
@@ -1,17 +1,9 @@
-﻿using System;
-using System.Drawing.Text;
-using System.IO;
-using System.Linq;
-using System.Text.Encodings.Web;
-using System.Threading.Tasks;
+﻿using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Html;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.TagHelpers;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Org.BouncyCastle.Utilities.Collections;
-using System.Collections.Generic;
 
 namespace League.TagHelpers;
 
@@ -86,7 +78,7 @@ public class SiteValidationSummaryTagHelper : TagHelper
 
     /// <summary>
     /// If <see cref="F:Microsoft.AspNetCore.Mvc.Rendering.ValidationSummary.All" /> or <see cref="F:Microsoft.AspNetCore.Mvc.Rendering.ValidationSummary.ModelOnly" />, appends a validation
-    /// summary. Otherwise (<see cref="F:Microsoft.AspNetCore.Mvc.Rendering.ValidationSummary.None" />, the default), this tag helper does nothing.
+    /// summary. Otherwise, (<see cref="F:Microsoft.AspNetCore.Mvc.Rendering.ValidationSummary.None" />, the default), this tag helper does nothing.
     /// </summary>
     /// <exception cref="T:System.ArgumentException">
     /// Thrown if setter is called with an undefined <see cref="P:Microsoft.AspNetCore.Mvc.TagHelpers.ValidationSummaryTagHelper.ValidationSummary" /> value e.g.
@@ -103,7 +95,7 @@ public class SiteValidationSummaryTagHelper : TagHelper
         set
         {
             if ((uint) value > 2U)
-                throw new ArgumentException($"Undefined {nameof(ValidationSummary)} value",
+                throw new ArgumentException($@"Undefined {nameof(ValidationSummary)} value",
                     nameof(ValidationSummary));
             _validationSummaryEnum = value;
         }

--- a/League/Templates/Email/Localization/EmailResource.de.resx
+++ b/League/Templates/Email/Localization/EmailResource.de.resx
@@ -233,6 +233,10 @@
     <value>Keine Nachricht enthalten</value>
     <comment>ContactForm</comment>
   </data>
+  <data name="No sets" xml:space="preserve">
+    <value>Keine Sätze</value>
+    <comment>ResultEntered</comment>
+  </data>
   <data name="Number of changes" xml:space="preserve">
     <value>Anzahl Änderungen</value>
     <comment>ResultEntered, ChangeFixture</comment>

--- a/League/Templates/Email/ResultEnteredTxt.tpl
+++ b/League/Templates/Email/ResultEnteredTxt.tpl
@@ -12,6 +12,12 @@
 {{ end ~}}
 
 {{ L "Result" }}
+{{ if model.Match.Sets.size > 0 ~}}
+    {{~ L "Ball points" }} / {{ L "Set points" }}
+{{ else ~}}
+
+    {{~ L "No sets" ~}}
+{{ end ~}}
 {{ i = 0 }}
 {{ points = { homeball: 0, guestball: 0, homeset: 0, guestset: 0 } ~}}
 {{for set in model.Match.Sets ~}} 
@@ -20,7 +26,7 @@
     {{~ points.homeset = points.homeset + set.HomeSetPoints ~}}
     {{~ points.guestset = points.guestset + set.GuestSetPoints ~}}
     {{~ i = i + 1 ~}}
-    {{~ L "Set #{0}" i }}:  {{ set.HomeBallPoints | string.pad_left 2 }} : {{ set.GuestBallPoints }}
+    {{~ L "Set #{0}" i }}:  {{ set.HomeBallPoints | string.pad_left 2 }} : {{ set.GuestBallPoints | string.pad_right 2 }}  / {{ set.HomeSetPoints | string.pad_left 2 }} : {{ set.GuestSetPoints | string.pad_right 2 }}
 {{ end ~}}
 
 {{ padright = [ L "Ball points", L "Set points", L "Match points" ] | array.map "size" | array.sort | array.last ~}}

--- a/League/Views/Match/EnterResult.cshtml
+++ b/League/Views/Match/EnterResult.cshtml
@@ -1,5 +1,4 @@
 ﻿@using System.Globalization
-@using League.Controllers
 @using Microsoft.AspNetCore.Mvc.Localization
 @using Microsoft.AspNetCore.Mvc.ModelBinding
 @using TournamentManager.MultiTenancy
@@ -15,6 +14,16 @@
         return !ViewData.ModelState.IsValid && ViewData.ModelState.GetValidationState($"{nameof(Model.BallPoints)}-{setIndex}") == ModelValidationState.Invalid ? " input-validation-error" : string.Empty;
     }
 
+    string AddSetPointsErr(int setIndex)
+    {
+        return !ViewData.ModelState.IsValid && ViewData.ModelState.GetValidationState($"{nameof(Model.SetPoints)}-{setIndex}") == ModelValidationState.Invalid ? " input-validation-error" : string.Empty;
+    }
+
+    string AddMatchPointsErr()
+    {
+        return !ViewData.ModelState.IsValid && (ViewData.ModelState.GetValidationState($"{nameof(Model.HomePoints)}") == ModelValidationState.Invalid || ViewData.ModelState.GetValidationState($"{nameof(Model.GuestPoints)}") == ModelValidationState.Invalid) ? " input-validation-error" : string.Empty;
+    }
+
     string AddDateErr()
     {
         return !ViewData.ModelState.IsValid && ViewData.ModelState.GetValidationState(nameof(Model.MatchDate)) == ModelValidationState.Invalid ? " input-validation-error" : string.Empty;
@@ -23,10 +32,39 @@
 <div class="mb-0 pb-1">
     <h2 class="h2">@ViewData["Title"]</h2>
     <hr />
-    <form asp-controller="@nameof(Match)" asp-action="@nameof(Match.EnterResult)" asp-route-tenant="@tenantUrlSegment" method="post" role="form" novalidate>
+    <div site-authorize-resource site-resource="@Model.Match" site-requirement="@League.Authorization.MatchOperations.OverruleResult" class="mb-2">
+        @if (Model.IsOverruling)
+        {
+            <site-alert type="Info">
+                <div style="margin: 0 !important">
+                    @Localizer["Overruling is enabled"].
+                    [<a data-bs-toggle="collapse" href="#overruling-details" aria-expanded="false" class="d-inline-block collapsed link">@(Localizer["Details"])</a>]
+                </div>
+                <div id="overruling-details" class="collapse">
+                    <ul class="mb-0">
+                        <li>@Localizer["Results can be changed as long as the competition is running"].</li>
+                        <li>@Localizer["Points must be adjusted manually"].</li>
+                        <li>@Localizer["All sets containing empty fields will be discarded"].</li>
+                        <li>@Localizer["The result entry can be removed. The match goes back to fixtures."]</li>
+                        <li>@Localizer["Overruled results are flagged"].</li>
+                    </ul>
+                </div>
+                <a asp-action="@nameof(League.Controllers.Match.EnterResult)" asp-controller="@nameof(League.Controllers.Match)" asp-route-tenant="@TenantContext.SiteContext.UrlSegmentValue" asp-route-id="@Model.Id" class="link">@Localizer["Back standard form"]</a>
+            </site-alert>
+        }
+        else
+        {
+            <a asp-action="@nameof(League.Controllers.Match.OverruleResult)" asp-controller="@nameof(League.Controllers.Match)" asp-route-tenant="@TenantContext.SiteContext.UrlSegmentValue" asp-route-id="@Model.Id" class="btn btn-secondary">@Localizer["Enable overruling"]</a>
+        }
+    </div>
+    <form method="post" role="form" novalidate>
         <site-validation-summary show="All" warning="@Model.IsWarning"></site-validation-summary>
         <input name="IsValid" type="hidden" value="@ViewData.ModelState.IsValid.ToString()" />
         <input hidden="hidden" asp-for="Id" />
+        @if (Model.IsOverruling)
+        {
+            <input hidden="hidden" asp-for="IsOverruling"/>
+        }
         <input hidden="hidden" asp-for="Hash" />
         @if (Model.IsWarning)
         {
@@ -44,7 +82,7 @@
             </div>
         </div>
         <div class="row">
-            <div class="mb-3 col-12 col-md-5">
+            <div class="mb-3 col-12 col-md-4">
                 <label asp-for="MatchDate" class="form-label"></label>
                 <div id="@(Model.MatchDate)-c" class="input-group" data-input-type="date" data-td-target-input="nearest" data-td-target-toggle="nearest">
                     <input asp-for="MatchDate" type="text" asp-format="{0:@(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern)}" autofocus autocomplete="off" class="form-control@(AddDateErr())" aria-describedby="@nameof(Model.MatchDate)HelpBlock" />
@@ -90,18 +128,49 @@
             {
                 var counter = i;
                 <div class="row">
-                    <div class="mb-3 col-12">
-                        <label class="form-label">@Localizer["Set #{0}", i + 1]</label>
+                    <label class="form-label">@Localizer["Set #{0}", i + 1]</label>
+                    <div class="mb-3 col-12 col-md-4">
+                        @if (Model.IsOverruling)
+                        {
+                            <div class="form-text">@Localizer["Ball Points"]</div>
+                        }
                         <div class="input-group">
-                            <input asp-for="@Model.BallPoints[counter].Home" type="text" autocomplete="off" class="form-control text-start @(AddBallPointsErr(counter))" style="max-width:5em" aria-describedby="@nameof(Model.MatchDate)HelpBlock" />
+                            <input asp-for="@Model.BallPoints[counter].Home" type="text" autocomplete="off" class="form-control text-start @(AddBallPointsErr(counter))" style="max-width:5em"/>
                             <span class="input-group-text">
                                 :
                             </span>
-                            <input asp-for="@Model.BallPoints[counter].Guest" type="text" autocomplete="off" class="form-control text-end @(AddBallPointsErr(counter))" style="max-width:5em" aria-describedby="@nameof(Model.MatchDate)HelpBlock" />
+                            <input asp-for="@Model.BallPoints[counter].Guest" type="text" autocomplete="off" class="form-control text-end @(AddBallPointsErr(counter))" style="max-width:5em"/>
                         </div>
                     </div>
+                    
+                    @if (Model.IsOverruling)
+                    {
+                        <div class="mb-3 col-12 col-md-4">
+                            <div class="form-text">@Localizer["Set Points"]</div>
+                            <div class="input-group">
+                                <input asp-for="@Model.SetPoints[counter].Home" type="text" autocomplete="off" class="form-control text-start @(AddSetPointsErr(counter))" style="max-width:5em"/>
+                                <span class="input-group-text">
+                                    :
+                                </span>
+                                <input asp-for="@Model.SetPoints[counter].Guest" type="text" autocomplete="off" class="form-control text-end @(AddSetPointsErr(counter))" style="max-width:5em"/>
+                            </div>
+                        </div>
+                    }
                 </div>
             }
+        }
+        @if (Model.IsOverruling)
+        {
+            <div class="row">
+                <label class="form-label">@Localizer["Match Points"]</label>
+                <div class="input-group">
+                    <input asp-for="@Model.HomePoints" type="text" autocomplete="off" class="form-control text-start @(AddMatchPointsErr())" style="max-width:5em"/>
+                    <span class="input-group-text">
+                        :
+                    </span>
+                    <input asp-for="@Model.GuestPoints" type="text" autocomplete="off" class="form-control text-end @(AddMatchPointsErr())" style="max-width:5em"/>
+                </div>
+            </div>
         }
         <div class="row">
             <div class="mb-3 col-12 col-md-8">
@@ -126,10 +195,11 @@
                     }
                     else
                     {
-                        <a asp-controller="@nameof(Match)" asp-action="@nameof(Match.Fixtures)" asp-route-tenant="@tenantUrlSegment" class="btn btn-lg btn-secondary">@Localizer["Cancel"]</a>
+                        <a asp-controller="@nameof(League.Controllers.Match)" asp-action="@nameof(League.Controllers.Match.Fixtures)" asp-route-tenant="@tenantUrlSegment" class="btn btn-lg btn-secondary">@Localizer["Cancel"]</a>
                     }
                 }
-                <button type="submit" class="btn btn-lg btn-primary">@Localizer["Save"]</button>
+                <button type="submit" value="save" class="btn btn-lg btn-primary me-5" 
+                        asp-controller="@nameof(League.Controllers.Match)" asp-action="@nameof(League.Controllers.Match.EnterResult)" asp-route-tenant="@tenantUrlSegment">@Localizer["Save"]</button>
             </div>
         </div>
     </form>
@@ -140,7 +210,8 @@
 }
 @section scripts
 {
-    <script type="text/javascript" src="~/lib/tempus-dominus/tempus-dominus.all.min.js" asp-append-version="true"></script>    <script type="text/javascript">
+    <script type="text/javascript" src="~/lib/tempus-dominus/tempus-dominus.all.min.js" asp-append-version="true"></script>    
+    <script type="text/javascript">
         document.addEventListener('DOMContentLoaded', OnDOMContentLoaded, false);
         function OnDOMContentLoaded() {
             const locale = '@(CultureInfo.CurrentCulture.ToString())';

--- a/League/Views/Match/EnterResult.cshtml
+++ b/League/Views/Match/EnterResult.cshtml
@@ -3,7 +3,6 @@
 @using Microsoft.AspNetCore.Mvc.Localization
 @using Microsoft.AspNetCore.Mvc.ModelBinding
 @using TournamentManager.MultiTenancy
-@inject RegionInfo RegionInfo
 @inject IViewLocalizer Localizer
 @inject ITenantContext TenantContext
 @model League.Models.MatchViewModels.EnterResultViewModel

--- a/League/Views/Match/EnterResult.cshtml
+++ b/League/Views/Match/EnterResult.cshtml
@@ -10,9 +10,9 @@
     ViewData["Title"] = Localizer["Enter Match Result"].Value + " - " + Model.Tournament?.Name;
     var tenantUrlSegment = TenantContext.SiteContext.UrlSegmentValue;
 
-    string AddSetErr(int setIndex)
+    string AddBallPointsErr(int setIndex)
     {
-        return !ViewData.ModelState.IsValid && ViewData.ModelState.GetValidationState($"set-{setIndex}") == ModelValidationState.Invalid ? " input-validation-error" : string.Empty;
+        return !ViewData.ModelState.IsValid && ViewData.ModelState.GetValidationState($"{nameof(Model.BallPoints)}-{setIndex}") == ModelValidationState.Invalid ? " input-validation-error" : string.Empty;
     }
 
     string AddDateErr()
@@ -25,7 +25,7 @@
     <hr />
     <form asp-controller="@nameof(Match)" asp-action="@nameof(Match.EnterResult)" asp-route-tenant="@tenantUrlSegment" method="post" role="form" novalidate>
         <site-validation-summary show="All" warning="@Model.IsWarning"></site-validation-summary>
-        <input name="IsValid" type="hidden" value="@ViewData.ModelState.IsValid.ToString()" />@* needed for unobtrusive validation *@
+        <input name="IsValid" type="hidden" value="@ViewData.ModelState.IsValid.ToString()" />
         <input hidden="hidden" asp-for="Id" />
         <input hidden="hidden" asp-for="Hash" />
         @if (Model.IsWarning)
@@ -86,18 +86,18 @@
             </div>
         </div>
         @{
-            for (var i = 0; i < Model.Sets.Count; i++)
+            for (var i = 0; i < Model.BallPoints.Count; i++)
             {
-                var localI = i;
+                var counter = i;
                 <div class="row">
                     <div class="mb-3 col-12">
                         <label class="form-label">@Localizer["Set #{0}", i + 1]</label>
                         <div class="input-group">
-                            <input asp-for="@Model.Sets[localI].Home" type="text" autocomplete="off" class="form-control text-start @(AddSetErr(localI))" style="max-width:5em" aria-describedby="@nameof(Model.MatchDate)HelpBlock" />
+                            <input asp-for="@Model.BallPoints[counter].Home" type="text" autocomplete="off" class="form-control text-start @(AddBallPointsErr(counter))" style="max-width:5em" aria-describedby="@nameof(Model.MatchDate)HelpBlock" />
                             <span class="input-group-text">
                                 :
                             </span>
-                            <input asp-for="@Model.Sets[localI].Guest" type="text" autocomplete="off" class="form-control text-end @(AddSetErr(localI))" style="max-width:5em" aria-describedby="@nameof(Model.MatchDate)HelpBlock" />
+                            <input asp-for="@Model.BallPoints[counter].Guest" type="text" autocomplete="off" class="form-control text-end @(AddBallPointsErr(counter))" style="max-width:5em" aria-describedby="@nameof(Model.MatchDate)HelpBlock" />
                         </div>
                     </div>
                 </div>
@@ -154,7 +154,7 @@
             [].forEach.call(document.querySelectorAll('[data-input-type="time"]'), function (el) {
                 tdFactory.CreateTimePicker(el, '@(CultureInfo.CurrentCulture.DateTimeFormat.ShortTimePattern.Replace("tt", "T"))');
                 el._tempusDominus.updateOptions({
-                    stepping: 1,
+                    stepping: 1
                 });
             });
         };

--- a/League/Views/Match/EnterResult.de.resx
+++ b/League/Views/Match/EnterResult.de.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="All sets containing empty fields will be discarded" xml:space="preserve">
+    <value>Alle Sätze, die leere Felder enthalten, werden verworfen</value>
+  </data>
+  <data name="Back standard form" xml:space="preserve">
+    <value>Zurück zur Standardeingabe</value>
+  </data>
   <data name="Cancel" xml:space="preserve">
     <value>Abbrechen</value>
   </data>
@@ -126,23 +132,41 @@
   <data name="DD.MM.YYYY" xml:space="preserve">
     <value>TT.MM.JJJJ</value>
   </data>
+  <data name="Enable overruling" xml:space="preserve">
+    <value>Übersteuern aktivieren</value>
+  </data>
   <data name="Enter Match Result" xml:space="preserve">
     <value>Spielergebnis eintragen</value>
   </data>
   <data name="Opponents" xml:space="preserve">
     <value>Begegnung</value>
   </data>
+  <data name="Overruled results are flagged" xml:space="preserve">
+    <value>Übersteuerte Ergebnisse werden gekennzeichnet</value>
+  </data>
+  <data name="Overruling is enabled" xml:space="preserve">
+    <value>Übersteuern ist aktiviert</value>
+  </data>
   <data name="Please double-check all entries before saving" xml:space="preserve">
     <value>Bitte die Angaben vor dem Speichern kontrollieren</value>
   </data>
+  <data name="Points must be adjusted manually" xml:space="preserve">
+    <value>Punkte müssen manuell festgelegt werden</value>
+  </data>
   <data name="Remarks become part of the result submission" xml:space="preserve">
     <value>Anmerkungen sind Teil der Ergebnismeldung</value>
+  </data>
+  <data name="Results can be changed as long as the competition is running" xml:space="preserve">
+    <value>Ergebnisse können geändert werden, solange der Wettbewerb läuft</value>
   </data>
   <data name="Save" xml:space="preserve">
     <value>Speichern</value>
   </data>
   <data name="Set #{0}" xml:space="preserve">
     <value>{0}. Satz</value>
+  </data>
+  <data name="The result entry can be removed. The match goes back to fixtures." xml:space="preserve">
+    <value>Der Ergebniseintrag kann entfernt werden. Das Spiel geht zurück in den Spielplan.</value>
   </data>
   <data name="Time format" xml:space="preserve">
     <value>Zeitformat</value>

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ The default database names are `TestOrg` and `OtherOrg`. You may change these na
 
 ### Build JavaScript and CSS
 
-    * Run `npm install` in the `League` directory to install the required npm packages.
-    * Run task 'prod' from Task Runner Explorer in Visual Studio to build the JavaScript and CSS files.
+* Open the Terminal, and navigate to the `League` project directory.
+* Run `npm install` to install the required `npm` packages.
+* Run `node .\node_modules\grunt-cli\bin\grunt prod` to build the JavaScript and CSS files (or run task 'prod' from Task Runner Explorer in Visual Studio). They will be stored in the `wwwroot` directory.
 
 ### Admin login
 

--- a/TournamentManager/TournamentManager.Tests/ModelValidators/SetsValidatorTests.cs
+++ b/TournamentManager/TournamentManager.Tests/ModelValidators/SetsValidatorTests.cs
@@ -11,7 +11,7 @@ public class SetsValidatorTests
     [Test]
     public void All_Ids_Have_A_Check_Function()
     {
-        var sv = new SetsValidator(new List<SetEntity>(), (new TenantContext(), (new MatchRuleEntity(1), new SetRuleEntity(1))));
+        var sv = new SetsValidator(new List<SetEntity>(), (new TenantContext(), (new MatchRuleEntity(1), new SetRuleEntity(1))), MatchValidationMode.Default);
 
         var enums = Enum.GetNames(typeof(SetsValidator.FactId)).ToList();
         foreach (var e in enums)
@@ -34,7 +34,7 @@ public class SetsValidatorTests
         {
             sets.Add(new SetEntity());
         }
-        var sv = new SetsValidator(sets, (new TenantContext(), (new MatchRuleEntity {BestOf = false, NumOfSets = 3}, new SetRuleEntity())));
+        var sv = new SetsValidator(sets, (new TenantContext(), (new MatchRuleEntity {BestOf = false, NumOfSets = 3}, new SetRuleEntity())), MatchValidationMode.Default);
         await sv.CheckAsync(SetsValidator.FactId.MinAndMaxOfSetsPlayed, CancellationToken.None);
         Assert.Multiple(() =>
             {
@@ -66,7 +66,7 @@ public class SetsValidatorTests
             sets.Add(new SetEntity());
         }
 
-        var sv = new SetsValidator(sets, (new TenantContext(), (new MatchRuleEntity { BestOf = true, NumOfSets = 3 }, new SetRuleEntity())));
+        var sv = new SetsValidator(sets, (new TenantContext(), (new MatchRuleEntity { BestOf = true, NumOfSets = 3 }, new SetRuleEntity())), MatchValidationMode.Default);
         await sv.CheckAsync(SetsValidator.FactId.BestOfMinAndMaxOfSetsPlayed, CancellationToken.None);
         Assert.Multiple(() =>
             {
@@ -101,7 +101,7 @@ public class SetsValidatorTests
 
         var matchRule = new MatchRuleEntity() {BestOf = true, NumOfSets = 2};
             
-        var sv = new SetsValidator(sets, (new TenantContext(), (matchRule, setRule)));
+        var sv = new SetsValidator(sets, (new TenantContext(), (matchRule, setRule)), MatchValidationMode.Default);
         await sv.CheckAsync(CancellationToken.None);
         var errorFacts = sv.GetFailedFacts();
         Assert.Multiple(() =>
@@ -125,7 +125,7 @@ public class SetsValidatorTests
 
         var matchRule = new MatchRuleEntity() { BestOf = true, NumOfSets = 2 };
 
-        var sv = new SetsValidator(sets, (new TenantContext(), (matchRule, new SetRuleEntity())));
+        var sv = new SetsValidator(sets, (new TenantContext(), (matchRule, new SetRuleEntity())), MatchValidationMode.Default);
         await sv.CheckAsync(SetsValidator.FactId.BestOfRequiredTieBreakPlayed, CancellationToken.None);
         var factResult = sv.GetFailedFacts().First(f => f.Id == SetsValidator.FactId.BestOfRequiredTieBreakPlayed);
         Assert.Multiple(() =>
@@ -154,7 +154,7 @@ public class SetsValidatorTests
         var setRule = new SetRuleEntity {PointsSetWon = 1, PointsSetLost = 0, PointsSetTie = 0};
         var matchRule = new MatchRuleEntity { BestOf = true, NumOfSets = 2 };
 
-        var sv = new SetsValidator(sets, (new TenantContext(), (matchRule, new SetRuleEntity())));
+        var sv = new SetsValidator(sets, (new TenantContext(), (matchRule, new SetRuleEntity())), MatchValidationMode.Default);
         await sv.CheckAsync(SetsValidator.FactId.BestOfNoMatchAfterBestOfReached, CancellationToken.None);
         var factResult = sv.GetFailedFacts().First(f => f.Id == SetsValidator.FactId.BestOfNoMatchAfterBestOfReached);
         Assert.Multiple(() =>
@@ -173,7 +173,7 @@ public class SetsValidatorTests
     [Test]
     public void Check_FieldName_Of_Facts()
     {
-        var sv = new SetsValidator(new List<SetEntity>(), (new TenantContext(), (new MatchRuleEntity(), new SetRuleEntity())));
+        var sv = new SetsValidator(new List<SetEntity>(), (new TenantContext(), (new MatchRuleEntity(), new SetRuleEntity())), MatchValidationMode.Default);
 
         foreach (var fact in sv.Facts)
         {

--- a/TournamentManager/TournamentManager.Tests/ModelValidators/SetsValidatorTests.cs
+++ b/TournamentManager/TournamentManager.Tests/ModelValidators/SetsValidatorTests.cs
@@ -35,7 +35,7 @@ public class SetsValidatorTests
             sets.Add(new SetEntity());
         }
         var sv = new SetsValidator(sets, (new TenantContext(), (new MatchRuleEntity {BestOf = false, NumOfSets = 3}, new SetRuleEntity())));
-        await sv.CheckAsync(SetsValidator.FactId.MixAndMaxOfSetsPlayed, CancellationToken.None);
+        await sv.CheckAsync(SetsValidator.FactId.MinAndMaxOfSetsPlayed, CancellationToken.None);
         Assert.Multiple(() =>
             {
                 if (shouldSucceed)
@@ -44,8 +44,8 @@ public class SetsValidatorTests
                 }
                 else
                 {
-                    Assert.That(sv.GetFailedFacts().First(f => f.Id == SetsValidator.FactId.MixAndMaxOfSetsPlayed).Success, Is.False);
-                    Assert.That(sv.GetFailedFacts().First(f => f.Id == SetsValidator.FactId.MixAndMaxOfSetsPlayed).Message, Is.Not.Null);
+                    Assert.That(sv.GetFailedFacts().First(f => f.Id == SetsValidator.FactId.MinAndMaxOfSetsPlayed).Success, Is.False);
+                    Assert.That(sv.GetFailedFacts().First(f => f.Id == SetsValidator.FactId.MinAndMaxOfSetsPlayed).Message, Is.Not.Null);
                 }
             }
         );

--- a/TournamentManager/TournamentManager.Tests/ModelValidators/SingleSetValidatorTests.cs
+++ b/TournamentManager/TournamentManager.Tests/ModelValidators/SingleSetValidatorTests.cs
@@ -12,7 +12,7 @@ public class SingleSetValidatorTests
     public void All_Ids_Have_A_Check_Function()
     {
         var set = new SetEntity();
-        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1)));
+        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1)), MatchValidationMode.Default);
 
         var enums = Enum.GetNames(typeof(SingleSetValidator.FactId)).ToList();
         foreach (var e in enums)
@@ -30,7 +30,7 @@ public class SingleSetValidatorTests
     public async Task Ball_Points_Are_Not_Negative(int homePoints, int guestPoints, bool expected)
     {
         var set = new SetEntity {HomeBallPoints = homePoints, GuestBallPoints = guestPoints};
-        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1)));
+        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1)), MatchValidationMode.Default);
         var factResult = await sv.CheckAsync(SingleSetValidator.FactId.BallPointsNotNegative, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -51,7 +51,7 @@ public class SingleSetValidatorTests
     public async Task Allow_Tie_In_Regular_Sets_If_Rule_Allows(int homePoints, int guestPoints, bool expected)
     {
         var set = new SetEntity { HomeBallPoints = homePoints, GuestBallPoints = guestPoints, IsTieBreak = false};
-        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { PointsDiffToWinRegular = 0, PointsDiffToWinTiebreak = 0 }));
+        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { PointsDiffToWinRegular = 0, PointsDiffToWinTiebreak = 0 }), MatchValidationMode.Default);
         var factResult = await sv.CheckAsync(SingleSetValidator.FactId.TieIsAllowed, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -72,7 +72,7 @@ public class SingleSetValidatorTests
     public async Task Disallow_Tie_In_Regular_Sets(int homePoints, int guestPoints, bool expected)
     {
         var set = new SetEntity { HomeBallPoints = homePoints, GuestBallPoints = guestPoints, IsTieBreak = false };
-        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { PointsDiffToWinRegular = 2, PointsDiffToWinTiebreak = 2 }));
+        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { PointsDiffToWinRegular = 2, PointsDiffToWinTiebreak = 2 }), MatchValidationMode.Default);
         var factResult = await sv.CheckAsync(SingleSetValidator.FactId.TieIsAllowed, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -93,7 +93,7 @@ public class SingleSetValidatorTests
     public async Task Allow_Tie_In_TieBreak_Sets_If_Rule_Allows(int homePoints, int guestPoints, bool expected)
     {
         var set = new SetEntity { HomeBallPoints = homePoints, GuestBallPoints = guestPoints, IsTieBreak = true };
-        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { PointsDiffToWinRegular = 0, PointsDiffToWinTiebreak = 0 }));
+        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { PointsDiffToWinRegular = 0, PointsDiffToWinTiebreak = 0 }), MatchValidationMode.Default);
         var factResult = await sv.CheckAsync(SingleSetValidator.FactId.TieIsAllowed, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -114,7 +114,7 @@ public class SingleSetValidatorTests
     public async Task Disallow_Tie_In_TieBreak_Sets(int homePoints, int guestPoints, bool expected)
     {
         var set = new SetEntity { HomeBallPoints = homePoints, GuestBallPoints = guestPoints, IsTieBreak = true };
-        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { PointsDiffToWinRegular = 2, PointsDiffToWinTiebreak = 2 }));
+        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { PointsDiffToWinRegular = 2, PointsDiffToWinTiebreak = 2 }), MatchValidationMode.Default);
         var factResult = await sv.CheckAsync(SingleSetValidator.FactId.TieIsAllowed, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -137,7 +137,7 @@ public class SingleSetValidatorTests
     public async Task Num_Of_BallPoints_To_Win_Is_Reached(int homePoints, int guestPoints, bool isTieBreak, bool expected)
     {
         var set = new SetEntity { HomeBallPoints = homePoints, GuestBallPoints = guestPoints, IsTieBreak = isTieBreak };
-        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { NumOfPointsToWinRegular = 25, NumOfPointsToWinTiebreak = 15 }));
+        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { NumOfPointsToWinRegular = 25, NumOfPointsToWinTiebreak = 15 }), MatchValidationMode.Default);
         var factResult = await sv.CheckAsync(SingleSetValidator.FactId.NumOfPointsToWinReached, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -158,7 +158,7 @@ public class SingleSetValidatorTests
     {
         // tie-break is ignored
         var set = new SetEntity { HomeBallPoints = homePoints, GuestBallPoints = guestPoints, IsTieBreak = isTieBreak };
-        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { NumOfPointsToWinRegular = 25, PointsDiffToWinRegular = 1, NumOfPointsToWinTiebreak = 15, PointsDiffToWinTiebreak = 1}));
+        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { NumOfPointsToWinRegular = 25, PointsDiffToWinRegular = 1, NumOfPointsToWinTiebreak = 15, PointsDiffToWinTiebreak = 1}), MatchValidationMode.Default);
         var factResult = await sv.CheckAsync(SingleSetValidator.FactId.RegularWinReachedWithOnePointAhead, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -180,7 +180,7 @@ public class SingleSetValidatorTests
     {
         // regular set is ignored
         var set = new SetEntity { HomeBallPoints = homePoints, GuestBallPoints = guestPoints, IsTieBreak = isTieBreak };
-        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { NumOfPointsToWinRegular = 25, PointsDiffToWinRegular = 1, NumOfPointsToWinTiebreak = 15, PointsDiffToWinTiebreak = 1 }));
+        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { NumOfPointsToWinRegular = 25, PointsDiffToWinRegular = 1, NumOfPointsToWinTiebreak = 15, PointsDiffToWinTiebreak = 1 }), MatchValidationMode.Default);
         var factResult = await sv.CheckAsync(SingleSetValidator.FactId.TieBreakWinReachedWithOnePointAhead, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -202,7 +202,7 @@ public class SingleSetValidatorTests
     {
         // tie-break is ignored
         var set = new SetEntity { HomeBallPoints = homePoints, GuestBallPoints = guestPoints, IsTieBreak = isTieBreak };
-        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { NumOfPointsToWinRegular = 25, PointsDiffToWinRegular = 2, NumOfPointsToWinTiebreak = 15, PointsDiffToWinTiebreak = 2 }));
+        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { NumOfPointsToWinRegular = 25, PointsDiffToWinRegular = 2, NumOfPointsToWinTiebreak = 15, PointsDiffToWinTiebreak = 2 }), MatchValidationMode.Default);
         var factResult = await sv.CheckAsync(SingleSetValidator.FactId.RegularWinReachedWithTwoPlusPointsAhead, CancellationToken.None);
         Assert.Multiple(() =>
         {
@@ -224,8 +224,27 @@ public class SingleSetValidatorTests
     {
         // regular sets are ignored
         var set = new SetEntity { HomeBallPoints = homePoints, GuestBallPoints = guestPoints, IsTieBreak = isTieBreak };
-        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { NumOfPointsToWinRegular = 25, PointsDiffToWinRegular = 2, NumOfPointsToWinTiebreak = 15, PointsDiffToWinTiebreak = 2 }));
+        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { NumOfPointsToWinRegular = 25, PointsDiffToWinRegular = 2, NumOfPointsToWinTiebreak = 15, PointsDiffToWinTiebreak = 2 }), MatchValidationMode.Default);
         var factResult = await sv.CheckAsync(SingleSetValidator.FactId.TieBreakWinReachedWithTwoPlusPointsAhead, CancellationToken.None);
+        Assert.Multiple(() =>
+        {
+            Assert.That(factResult.Success, Is.EqualTo(expected));
+            Assert.That(factResult.Message, Is.Not.Null);
+            Assert.That(factResult.Exception, Is.Null);
+        });
+    }
+
+    [TestCase(0, 0, true)]
+    [TestCase(0, 1, true)]
+    [TestCase(2, 1, true)]
+    [TestCase(-1, 1, false)]
+    [TestCase(10, 1, false)]
+    public async Task Invalid_Set_Points_Should_Fail(int homeSetPoints, int guestSetPoints, bool expected)
+    {
+        // regular sets are ignored
+        var set = new SetEntity { HomeSetPoints = homeSetPoints, GuestSetPoints = guestSetPoints };
+        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { PointsSetWon = 2, PointsSetLost = 0, PointsSetTie = 1 }), MatchValidationMode.Overrule);
+        var factResult = await sv.CheckAsync(SingleSetValidator.FactId.SetPointsAreValid, CancellationToken.None);
         Assert.Multiple(() =>
         {
             Assert.That(factResult.Success, Is.EqualTo(expected));
@@ -247,7 +266,7 @@ public class SingleSetValidatorTests
     public async Task Test_for_all_Facts(int homePoints, int guestPoints, bool isTieBreak, SingleSetValidator.FactId expected)
     {
         var set = new SetEntity { HomeBallPoints = homePoints, GuestBallPoints = guestPoints, IsTieBreak = isTieBreak };
-        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { NumOfPointsToWinRegular = 25, PointsDiffToWinRegular = 2, NumOfPointsToWinTiebreak = 15, PointsDiffToWinTiebreak = 2 }));
+        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { NumOfPointsToWinRegular = 25, PointsDiffToWinRegular = 2, NumOfPointsToWinTiebreak = 15, PointsDiffToWinTiebreak = 2 }), MatchValidationMode.Default);
         var result = await sv.CheckAsync(CancellationToken.None);
         Assert.That(sv.GetFailedFacts().First(r => !r.Success).Id, Is.EqualTo(expected));
     }
@@ -259,20 +278,21 @@ public class SingleSetValidatorTests
     public void Test_for_all_Facts_Should_Succeed(int homePoints, int guestPoints, bool isTieBreak)
     {
         var set = new SetEntity { HomeBallPoints = homePoints, GuestBallPoints = guestPoints, IsTieBreak = isTieBreak };
-        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { NumOfPointsToWinRegular = 25, PointsDiffToWinRegular = 2, NumOfPointsToWinTiebreak = 15, PointsDiffToWinTiebreak = 2 }));
+        var sv = new SingleSetValidator(set, (new TenantContext(), new SetRuleEntity(1) { NumOfPointsToWinRegular = 25, PointsDiffToWinRegular = 2, NumOfPointsToWinTiebreak = 15, PointsDiffToWinTiebreak = 2 }), MatchValidationMode.Default);
         Assert.That(sv.GetFailedFacts(), Is.Empty);
     }
 
     [Test]
     public void Check_FieldName_Of_Facts()
     {
-        var fv = new SingleSetValidator(new SetEntity(),  (new TenantContext(), new SetRuleEntity()));
+        var fv = new SingleSetValidator(new SetEntity(),  (new TenantContext(), new SetRuleEntity()), MatchValidationMode.Default);
 
         foreach (var fact in fv.Facts)
         {
             switch (fact.Id)
             {
                 case SingleSetValidator.FactId.BallPointsNotNegative:
+                case SingleSetValidator.FactId.SetPointsAreValid:
                 case SingleSetValidator.FactId.TieIsAllowed:
                 case SingleSetValidator.FactId.NumOfPointsToWinReached:
                 case SingleSetValidator.FactId.RegularWinReachedWithOnePointAhead:

--- a/TournamentManager/TournamentManager/ExtensionMethods/SetEntityListExtensions.cs
+++ b/TournamentManager/TournamentManager/ExtensionMethods/SetEntityListExtensions.cs
@@ -90,23 +90,57 @@ public static class SetEntityListExtensions
 
     /// <summary>
     /// Adds a <see cref="IList{T}"/> of <see cref="PointResult"/>s to the <see cref="IList{T}"/> of <see cref="SetEntity"/>.
+    /// Sets with <see langword="null"/> for home or guest points are skipped.
     /// </summary>
     /// <param name="setList"></param>
     /// <param name="matchId">The <see cref="MatchEntity.Id"/></param>
-    /// <param name="pointResults">The <see cref="IList{T}"/> of <see cref="PointResult"/>.</param>
-    public static void Add(this IList<SetEntity> setList, long matchId, IList<PointResult> pointResults)
+    /// <param name="ballPoints">The <see cref="IList{T}"/> of <see cref="PointResult"/>.</param>
+    public static void Add(this IList<SetEntity> setList, long matchId, IList<PointResult> ballPoints)
     {
         var sequenceNo = 0;
-        foreach (var pointResult in pointResults)
+        foreach (var ballPoint in ballPoints)
         {
-            if(pointResult.Home is null || pointResult.Guest is null)
+            // This should not happen after validation
+            if(ballPoint.Home is null || ballPoint.Guest is null)
                 continue;
 
             setList.Add(new SetEntity {
                 MatchId = matchId,
                 SequenceNo = ++sequenceNo,
-                HomeBallPoints = pointResult.Home.Value,
-                GuestBallPoints = pointResult.Guest.Value
+                HomeBallPoints = ballPoint.Home.Value,
+                GuestBallPoints = ballPoint.Guest.Value
+            });
+        }
+    }
+
+    /// <summary>
+    /// Adds a <see cref="IList{T}"/> of ball and set <see cref="PointResult"/>s to the <see cref="IList{T}"/> of <see cref="SetEntity"/>.
+    /// Sets with <see langword="null"/> for home/guest ball or set points are skipped.
+    /// Both lists are expected to be equal in size. Missing set points are treated as <see langword="null"/>.
+    /// </summary>
+    /// <param name="setList"></param>
+    /// <param name="matchId">The <see cref="MatchEntity.Id"/></param>
+    /// <param name="ballPoints">The <see cref="IList{T}"/> of ball <see cref="PointResult"/>.</param>
+    /// <param name="setPoints">The <see cref="IList{T}"/> of set <see cref="PointResult"/>.</param>
+    public static void Add(this IList<SetEntity> setList, long matchId, IList<PointResult> ballPoints, IList<PointResult> setPoints)
+    {
+        var sequenceNo = 0;
+        for (var index = 0; index < ballPoints.Count; index++)
+        {
+            var ballPoint = ballPoints[index];
+            var setPoint = index < setPoints.Count ? setPoints[index] : new PointResult();
+            // This should not happen after validation
+            if (ballPoint.Home is null || ballPoint.Guest is null ||
+                setPoint.Home is null || setPoint.Guest is null)
+                continue;
+
+            setList.Add(new SetEntity {
+                MatchId = matchId,
+                SequenceNo = ++sequenceNo,
+                HomeBallPoints = ballPoint.Home.Value,
+                GuestBallPoints = ballPoint.Guest.Value,
+                HomeSetPoints = setPoint.Home.Value,
+                GuestSetPoints = setPoint.Guest.Value
             });
         }
     }

--- a/TournamentManager/TournamentManager/Match/Calendar.cs
+++ b/TournamentManager/TournamentManager/Match/Calendar.cs
@@ -111,7 +111,7 @@ public class Calendar
             evt.Description = !string.IsNullOrWhiteSpace(DescriptionOpponentsFormat)
                 ? string.Format(DescriptionOpponentsFormat, match.HomeTeamNameForRound, match.GuestTeamNameForRound)
                 : string.Empty;
-            if (match.VenueLongitude.HasValue && match.VenueLatitude.HasValue && !string.IsNullOrWhiteSpace(DescriptionGoogleMapsFormat))
+            if (match is { VenueLongitude: not null, VenueLatitude: not null } && !string.IsNullOrWhiteSpace(DescriptionGoogleMapsFormat))
                 evt.Description += "\n" + string.Format(DescriptionGoogleMapsFormat,
                     match.VenueLatitude.Value.ToString(System.Globalization.CultureInfo.InvariantCulture),
                     match.VenueLongitude.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));
@@ -179,7 +179,7 @@ public class Calendar
             evt.Description = !string.IsNullOrWhiteSpace(DescriptionOpponentsFormat)
                 ? string.Format(DescriptionOpponentsFormat, match.HomeTeamNameForRound, match.GuestTeamNameForRound)
                 : string.Empty;
-            if (match.VenueLongitude.HasValue && match.VenueLatitude.HasValue && !string.IsNullOrWhiteSpace(DescriptionGoogleMapsFormat))
+            if (match is { VenueLongitude: not null, VenueLatitude: not null } && !string.IsNullOrWhiteSpace(DescriptionGoogleMapsFormat))
                 evt.Description += "\n" + string.Format(DescriptionGoogleMapsFormat,
                     match.VenueLatitude.Value.ToString(System.Globalization.CultureInfo.InvariantCulture),
                     match.VenueLongitude.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));

--- a/TournamentManager/TournamentManager/ModelValidators/AbstractValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/AbstractValidator.cs
@@ -178,6 +178,21 @@ public abstract class AbstractValidator<TModel, TData, TFactId>
     }
 
     /// <summary>
+    /// Enables or disables the <see cref="Facts"/> with the given dictionary.
+    /// </summary>
+    /// <param name="facts">The facts to configure.</param>
+    protected void ConfigureFacts(IDictionary<TFactId, bool> facts)
+    {
+        foreach (var fact in Facts)
+        {
+            if (facts.TryGetValue(fact.Id, out var enabled))
+            {
+                fact.Enabled = enabled;
+            }
+        }
+    }
+
+    /// <summary>
     /// Invokes the Check for a fact with the <typeparamref name="TFactId"/> identifier.
     /// </summary>
     /// <param name="id">The identifier of the <see cref="Fact{TFactId}"/></param>

--- a/TournamentManager/TournamentManager/ModelValidators/AbstractValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/AbstractValidator.cs
@@ -230,7 +230,7 @@ public abstract class AbstractValidator<TModel, TData, TFactId>
             await CheckAsync(fact.Id, cancellationToken);
         }
         // stop after any not successful error facts
-        if (facts.Any(f => f.IsChecked && !f.Success)) return facts;
+        if (facts.Any(f => f is { IsChecked: true, Success: false })) return facts;
 
         // Process all other facts
         foreach (var fact in Facts.Where(f => !f.IsChecked))

--- a/TournamentManager/TournamentManager/ModelValidators/MatchResultValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/MatchResultValidator.cs
@@ -29,153 +29,176 @@ public class MatchResultValidator : AbstractValidator<MatchEntity, (ITenantConte
 
     public void CreateFacts()
     {
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.RealMatchDateIsSet,
-                FieldNames = new[] { nameof(Model.RealStart), nameof(Model.RealEnd) },
-                Enabled = true,
-                Type = FactType.Critical,
-                CheckAsync = (cancellationToken) => Task.FromResult(
-                    new FactResult
-                    {
-                        Message = MatchResultValidatorResource.ResourceManager.GetString(nameof(FactId.RealMatchDateIsSet)) ?? string.Empty,
-                        Success = Model.RealStart.HasValue && Model.RealEnd.HasValue
-                    })
-            });
+        Facts.Add(RealMatchDateIsSet());
+        Facts.Add(RealMatchDateTodayOrBefore());
+        Facts.Add(RealMatchDateWithinRoundLegs());
+        Facts.Add(SetsValidatorSuccessful());
+        Facts.Add(RealMatchDateEqualsFixture());
+        Facts.Add(RealMatchDurationIsPlausible());
+    }
 
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.RealMatchDateTodayOrBefore,
-                FieldNames = new[] { nameof(Model.RealStart), nameof(Model.RealEnd) },
-                Enabled = true,
-                Type = FactType.Error,
-                CheckAsync = (cancellationToken) => Task.FromResult(
-                    new FactResult
-                    {
-                        Message = MatchResultValidatorResource.ResourceManager.GetString(nameof(FactId.RealMatchDateTodayOrBefore)) ?? string.Empty,
-                        Success = Model.RealStart?.Date <= Today.Date && Model.RealEnd?.Date <= Today.Date
-                    })
-            });
+    private Fact<FactId> RealMatchDurationIsPlausible()
+    {
+        return new Fact<FactId>
+        {
+            // One ball point lasts for about 33 seconds (average over 1,024 matches with 169,845 ball points in 92,186 minutes)
+            // https://volleyball.de/nc/news/details/datum/2011/05/27/zahlenspiele-1025-spiele-dauerten-64-tage-und-26-minuten/
+            Id = FactId.RealMatchDurationIsPlausible,
+            FieldNames = new[] { nameof(Model.RealStart), nameof(Model.RealEnd) },
+            Enabled = true,
+            Type = FactType.Warning,
+            CheckAsync = (cancellationToken) => FactResult()
+        };
 
-        Facts.Add(
-            new Fact<FactId>
+        Task<FactResult> FactResult()
+        {
+            const int minDuration = 33 - 10;
+            const int maxDuration = 33 + 10;
+            var duration = Model is { RealStart: not null, RealEnd: not null } ? new DateTimePeriod(Model.RealStart, Model.RealEnd).Duration() : new TimeSpan(0);
+            var totalBallPoints = Model.Sets.GetTotalBallPoints();
+
+            return Task.FromResult(new FactResult
             {
-                Id = FactId.RealMatchDateWithinRoundLegs,
-                FieldNames = new[] {nameof(Model.RealStart), nameof(Model.RealEnd) },
-                Enabled = true,
-                Type = FactType.Error,
-                CheckAsync = async (cancellationToken) =>
+                Message = string.Format(MatchResultValidatorResource.ResourceManager.GetString(
+                                            nameof(FactId.RealMatchDurationIsPlausible)) ??
+                                        string.Empty, duration),
+                Success = Model is { RealStart: not null, RealEnd: not null }
+                          && (duration.TotalSeconds >= totalBallPoints * minDuration && duration.TotalSeconds <= totalBallPoints * maxDuration)
+            });
+        }
+    }
+
+    private Fact<FactId> RealMatchDateEqualsFixture()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.RealMatchDateEqualsFixture,
+            FieldNames = new[] { nameof(Model.RealStart), nameof(Model.RealEnd) },
+            Enabled = true,
+            Type = FactType.Warning,
+            CheckAsync = (cancellationToken) => Task.FromResult(
+                new FactResult
                 {
-                    var successResult = new FactResult
-                    {
-                        Message = MatchResultValidatorResource.ResourceManager.GetString(nameof(FactId.RealMatchDateWithinRoundLegs)) ?? string.Empty,
-                        Success = true
-                    };
+                    Message = MatchResultValidatorResource.ResourceManager.GetString(nameof(FactId.RealMatchDateEqualsFixture)) ?? string.Empty,
+                    Success = Model.RealStart.HasValue && Model is { RealEnd: not null, PlannedStart: not null }
+                                                       && Model.RealStart?.Date == Model.PlannedStart?.Date
+                })
+        };
+    }
 
-                    var round =
-                        await Data.TenantContext.DbContext.AppDb.RoundRepository.GetRoundWithLegsAsync(Model.RoundId,
-                            cancellationToken) ?? throw new InvalidOperationException($"Round Id '{Model.RoundId}' not found.");
+    private Fact<FactId> SetsValidatorSuccessful()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.SetsValidatorSuccessful,
+            FieldNames = new[] { string.Empty },
+            Enabled = true,
+            Type = FactType.Critical,
+            CheckAsync = async (cancellationToken) => await FactResult()
+        };
 
-                    if (!Model.RealStart.HasValue || !Model.RealEnd.HasValue || round.RoundLegs.Count == 0)
-                    {
-                        return successResult;
-                    }
-
-                    if (round.RoundLegs.Any(rl =>
-                            new DateTimePeriod(rl.StartDateTime, rl.EndDateTime).Contains(Model.RealStart))
-                        &&
-                        round.RoundLegs.Any(rl =>
-                            new DateTimePeriod(rl.StartDateTime, rl.EndDateTime).Contains(Model.RealEnd)))
-                    {
-                        return successResult;
-                    }
-
-                    var displayPeriods = string.Empty;
-                    const string joinWith = ", ";
-                    displayPeriods = round.RoundLegs.Aggregate(displayPeriods,
-                        (current, leg) =>
-                            current +
-                            $"{Data.TimeZoneConverter.ToZonedTime(leg.StartDateTime)?.DateTimeOffset.DateTime.ToShortDateString()} - {Data.TimeZoneConverter.ToZonedTime(leg.EndDateTime)?.DateTimeOffset.DateTime.ToShortDateString()}{joinWith}");
-                    displayPeriods = displayPeriods[..^joinWith.Length];
-
-                    return new FactResult
-                    {
-                        Message = string.Format(MatchResultValidatorResource.ResourceManager.GetString(
-                                                    nameof(FactId.RealMatchDateWithinRoundLegs)) ??
-                                                string.Empty, round.Description, displayPeriods),
-                        Success = false
-                    };
-                }
+        async Task<FactResult> FactResult()
+        {
+            if (!Model.IsOverruled)
+            {
+                await SetsValidator.CheckAsync(CancellationToken.None);
             }
-        );
 
-        Facts.Add(
-            new Fact<FactId>
+            return new FactResult
             {
-                Id = FactId.SetsValidatorSuccessful,
-                FieldNames = new[] { string.Empty },
-                Enabled = true,
-                Type = FactType.Critical,
-                CheckAsync = async (cancellationToken) =>
+                Message = MatchResultValidatorResource.ResourceManager.GetString(
+                    nameof(FactId.SetsValidatorSuccessful)) ?? string.Empty,
+                Success = SetsValidator.GetFailedFacts().Count == 0
+            };
+        }
+    }
+
+    private Fact<FactId> RealMatchDateWithinRoundLegs()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.RealMatchDateWithinRoundLegs,
+            FieldNames = new[] {nameof(Model.RealStart), nameof(Model.RealEnd) },
+            Enabled = true,
+            Type = FactType.Error,
+            CheckAsync = FactResult
+        };
+
+        async Task<FactResult> FactResult(CancellationToken cancellationToken)
+        {
+            var successResult = new FactResult
+            {
+                Message = MatchResultValidatorResource.ResourceManager.GetString(nameof(FactId.RealMatchDateWithinRoundLegs)) ?? string.Empty,
+                Success = true
+            };
+
+            var round =
+                await Data.TenantContext.DbContext.AppDb.RoundRepository.GetRoundWithLegsAsync(Model.RoundId,
+                    cancellationToken) ?? throw new InvalidOperationException($"Round Id '{Model.RoundId}' not found.");
+
+            if (!Model.RealStart.HasValue || !Model.RealEnd.HasValue || round.RoundLegs.Count == 0)
+            {
+                return successResult;
+            }
+
+            if (round.RoundLegs.Any(rl =>
+                    new DateTimePeriod(rl.StartDateTime, rl.EndDateTime).Contains(Model.RealStart))
+                &&
+                round.RoundLegs.Any(rl =>
+                    new DateTimePeriod(rl.StartDateTime, rl.EndDateTime).Contains(Model.RealEnd)))
+            {
+                return successResult;
+            }
+
+            var displayPeriods = string.Empty;
+            const string joinWith = ", ";
+            displayPeriods = round.RoundLegs.Aggregate(displayPeriods,
+                (current, leg) =>
+                    current +
+                    $"{Data.TimeZoneConverter.ToZonedTime(leg.StartDateTime)?.DateTimeOffset.DateTime.ToShortDateString()} - {Data.TimeZoneConverter.ToZonedTime(leg.EndDateTime)?.DateTimeOffset.DateTime.ToShortDateString()}{joinWith}");
+            displayPeriods = displayPeriods[..^joinWith.Length];
+
+            return new FactResult
+            {
+                Message = string.Format(MatchResultValidatorResource.ResourceManager.GetString(
+                                            nameof(FactId.RealMatchDateWithinRoundLegs)) ??
+                                        string.Empty, round.Description, displayPeriods),
+                Success = false
+            };
+        }
+    }
+
+    private Fact<FactId> RealMatchDateTodayOrBefore()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.RealMatchDateTodayOrBefore,
+            FieldNames = new[] { nameof(Model.RealStart), nameof(Model.RealEnd) },
+            Enabled = true,
+            Type = FactType.Error,
+            CheckAsync = (cancellationToken) => Task.FromResult(
+                new FactResult
                 {
-                    if (!Model.IsOverruled)
-                    {
-                        await SetsValidator.CheckAsync(CancellationToken.None);
-                    }
-                        
-                    return new FactResult
-                    {
-                        Message = MatchResultValidatorResource.ResourceManager.GetString(
-                            nameof(FactId.SetsValidatorSuccessful)) ?? string.Empty,
-                        Success = SetsValidator.GetFailedFacts().Count == 0
-                    };
-                }
-            });
+                    Message = MatchResultValidatorResource.ResourceManager.GetString(nameof(FactId.RealMatchDateTodayOrBefore)) ?? string.Empty,
+                    Success = Model.RealStart?.Date <= Today.Date && Model.RealEnd?.Date <= Today.Date
+                })
+        };
+    }
 
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.RealMatchDateEqualsFixture,
-                FieldNames = new[] { nameof(Model.RealStart), nameof(Model.RealEnd) },
-                Enabled = true,
-                Type = FactType.Warning,
-                CheckAsync = (cancellationToken) => Task.FromResult(
-                    new FactResult
-                    {
-                        Message = MatchResultValidatorResource.ResourceManager.GetString(nameof(FactId.RealMatchDateEqualsFixture)) ?? string.Empty,
-                        Success = Model.RealStart.HasValue && Model.RealEnd.HasValue
-                                                           && Model.PlannedStart.HasValue
-                                                           && Model.RealStart?.Date == Model.PlannedStart?.Date
-                    })
-            });
-
-        Facts.Add(
-            new Fact<FactId>
-            {
-                // One ball point lasts for about 33 seconds (average over 1,024 matches with 169,845 ball points in 92,186 minutes)
-                // https://volleyball.de/nc/news/details/datum/2011/05/27/zahlenspiele-1025-spiele-dauerten-64-tage-und-26-minuten/
-                Id = FactId.RealMatchDurationIsPlausible,
-                FieldNames = new[] { nameof(Model.RealStart), nameof(Model.RealEnd) },
-                Enabled = true,
-                Type = FactType.Warning,
-                CheckAsync = (cancellationToken) =>
+    private Fact<FactId> RealMatchDateIsSet()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.RealMatchDateIsSet,
+            FieldNames = new[] { nameof(Model.RealStart), nameof(Model.RealEnd) },
+            Enabled = true,
+            Type = FactType.Critical,
+            CheckAsync = (cancellationToken) => Task.FromResult(
+                new FactResult
                 {
-                    const int minDuration = 33 - 10;
-                    const int maxDuration = 33 + 10;
-                    var duration = Model.RealStart.HasValue && Model.RealEnd.HasValue ? new DateTimePeriod(Model.RealStart, Model.RealEnd).Duration() : new TimeSpan(0);
-                    var totalBallPoints = Model.Sets.GetTotalBallPoints();
-
-                    return Task.FromResult(new FactResult
-                    {
-                        Message = string.Format(MatchResultValidatorResource.ResourceManager.GetString(
-                                                    nameof(FactId.RealMatchDurationIsPlausible)) ??
-                                                string.Empty, duration),
-                        Success = Model.RealStart.HasValue && Model.RealEnd.HasValue
-                                                           && (duration.TotalSeconds >= totalBallPoints * minDuration && duration.TotalSeconds <= totalBallPoints * maxDuration)
-                    });
-                }
-            });
+                    Message = MatchResultValidatorResource.ResourceManager.GetString(nameof(FactId.RealMatchDateIsSet)) ?? string.Empty,
+                    Success = Model is { RealStart: not null, RealEnd: not null }
+                })
+        };
     }
 }

--- a/TournamentManager/TournamentManager/ModelValidators/MatchResultValidatorResource.Designer.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/MatchResultValidatorResource.Designer.cs
@@ -61,6 +61,15 @@ namespace TournamentManager.ModelValidators {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allowed match points are {0}.
+        /// </summary>
+        internal static string MatchPointsAreValid {
+            get {
+                return ResourceManager.GetString("MatchPointsAreValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Actual match day differs from the fixture.
         /// </summary>
         internal static string RealMatchDateEqualsFixture {

--- a/TournamentManager/TournamentManager/ModelValidators/MatchResultValidatorResource.de.resx
+++ b/TournamentManager/TournamentManager/ModelValidators/MatchResultValidatorResource.de.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="MatchPointsAreValid" xml:space="preserve">
+    <value>Erlaubte Spielpunkte sind {0}</value>
+  </data>
   <data name="RealMatchDateEqualsFixture" xml:space="preserve">
     <value>Der tatsächliche Spieltag weicht vom Spielplan ab</value>
   </data>

--- a/TournamentManager/TournamentManager/ModelValidators/MatchResultValidatorResource.resx
+++ b/TournamentManager/TournamentManager/ModelValidators/MatchResultValidatorResource.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="MatchPointsAreValid" xml:space="preserve">
+    <value>Allowed match points are {0}</value>
+  </data>
   <data name="RealMatchDateEqualsFixture" xml:space="preserve">
     <value>Actual match day differs from the fixture</value>
   </data>

--- a/TournamentManager/TournamentManager/ModelValidators/MatchValidationMode.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/MatchValidationMode.cs
@@ -1,0 +1,12 @@
+﻿namespace TournamentManager.ModelValidators;
+
+/// <summary>
+/// The mode to validate a match.
+/// This setting is used with the <see cref="MatchResultValidator"/>, <see cref="SetsValidator"/> and <see cref="SingleSetValidator"/>.
+/// </summary>
+public enum MatchValidationMode
+{
+    Default = 0,
+    Overrule
+}
+

--- a/TournamentManager/TournamentManager/ModelValidators/PhoneNumberValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/PhoneNumberValidator.cs
@@ -17,19 +17,23 @@ public class PhoneNumberValidator : AbstractValidator<string, (PhoneNumberServic
 
     private void CreateFacts()
     {
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.NumberIsValid,
-                FieldNames = new[] {"PhoneNumber"},
-                Enabled = true,
-                Type = FactType.Critical,
-                CheckAsync = (cancellationToken) => Task.FromResult(
-                    new FactResult
-                    {
-                        Message = PhoneNumberValidatorResource.NumberIsValid,
-                        Success = Data.PhoneNumberService.IsValid(Model, Data.Region.TwoLetterISORegionName)
-                    })
-            });
+        Facts.Add(NumberIsValid());
+    }
+
+    private Fact<FactId> NumberIsValid()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.NumberIsValid,
+            FieldNames = new[] {"PhoneNumber"},
+            Enabled = true,
+            Type = FactType.Critical,
+            CheckAsync = (cancellationToken) => Task.FromResult(
+                new FactResult
+                {
+                    Message = PhoneNumberValidatorResource.NumberIsValid,
+                    Success = Data.PhoneNumberService.IsValid(Model, Data.Region.TwoLetterISORegionName)
+                })
+        };
     }
 }

--- a/TournamentManager/TournamentManager/ModelValidators/SetsValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/SetsValidator.cs
@@ -25,9 +25,9 @@ public class SetsValidator : AbstractValidator<IList<SetEntity>, (ITenantContext
 
     private void CreateFacts()
     {
+        Facts.Add(AllSetsAreValid());
         Facts.Add(MinAndMaxOfSetsPlayed());
         Facts.Add(BestOfMinAndMaxOfSetsPlayed());
-        Facts.Add(AllSetsAreValid());
         Facts.Add(BestOfRequiredTieBreakPlayed());
         Facts.Add(BestOfNoMatchAfterBestOfReached());
     }

--- a/TournamentManager/TournamentManager/ModelValidators/SetsValidatorResource.Designer.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/SetsValidatorResource.Designer.cs
@@ -19,7 +19,7 @@ namespace TournamentManager.ModelValidators {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SetsValidatorResource {
@@ -72,9 +72,9 @@ namespace TournamentManager.ModelValidators {
         /// <summary>
         ///   Looks up a localized string similar to Best {0} out of {1} sets must be played.
         /// </summary>
-        internal static string BestOfMixAndMaxOfSetsPlayed {
+        internal static string BestOfMinAndMaxOfSetsPlayed {
             get {
-                return ResourceManager.GetString("BestOfMixAndMaxOfSetsPlayed", resourceCulture);
+                return ResourceManager.GetString("BestOfMinAndMaxOfSetsPlayed", resourceCulture);
             }
         }
         
@@ -99,9 +99,9 @@ namespace TournamentManager.ModelValidators {
         /// <summary>
         ///   Looks up a localized string similar to {0} sets must be played.
         /// </summary>
-        internal static string MixAndMaxOfSetsPlayed {
+        internal static string MinAndMaxOfSetsPlayed {
             get {
-                return ResourceManager.GetString("MixAndMaxOfSetsPlayed", resourceCulture);
+                return ResourceManager.GetString("MinAndMaxOfSetsPlayed", resourceCulture);
             }
         }
     }

--- a/TournamentManager/TournamentManager/ModelValidators/SetsValidatorResource.de.resx
+++ b/TournamentManager/TournamentManager/ModelValidators/SetsValidatorResource.de.resx
@@ -120,7 +120,7 @@
   <data name="AllSetsAreValid" xml:space="preserve">
     <value>Mindestens ein Satz ist fehlerhaft</value>
   </data>
-  <data name="BestOfMixAndMaxOfSetsPlayed" xml:space="preserve">
+  <data name="BestOfMinAndMaxOfSetsPlayed" xml:space="preserve">
     <value>{0} Gewinnsätze aus max. {1} Sätzen sind zu spielen</value>
   </data>
   <data name="BestOfNoMatchAfterBestOfReached" xml:space="preserve">
@@ -129,7 +129,7 @@
   <data name="BestOfRequiredTieBreakPlayed" xml:space="preserve">
     <value>Der letzte Satz (beste {0} von max. {1}) muss ein Tie-Break sein</value>
   </data>
-  <data name="MixAndMaxOfSetsPlayed" xml:space="preserve">
+  <data name="MinAndMaxOfSetsPlayed" xml:space="preserve">
     <value>Es müssen {0} Sätze gespielt sein</value>
   </data>
 </root>

--- a/TournamentManager/TournamentManager/ModelValidators/SetsValidatorResource.resx
+++ b/TournamentManager/TournamentManager/ModelValidators/SetsValidatorResource.resx
@@ -120,7 +120,7 @@
   <data name="AllSetsAreValid" xml:space="preserve">
     <value>At least one set is invalid</value>
   </data>
-  <data name="BestOfMixAndMaxOfSetsPlayed" xml:space="preserve">
+  <data name="BestOfMinAndMaxOfSetsPlayed" xml:space="preserve">
     <value>Best {0} out of {1} sets must be played</value>
   </data>
   <data name="BestOfNoMatchAfterBestOfReached" xml:space="preserve">
@@ -129,7 +129,7 @@
   <data name="BestOfRequiredTieBreakPlayed" xml:space="preserve">
     <value>The last set (best {0} of max. {1}) must be a tie-break</value>
   </data>
-  <data name="MixAndMaxOfSetsPlayed" xml:space="preserve">
+  <data name="MinAndMaxOfSetsPlayed" xml:space="preserve">
     <value>{0} sets must be played</value>
   </data>
 </root>

--- a/TournamentManager/TournamentManager/ModelValidators/SingleSetValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/SingleSetValidator.cs
@@ -30,289 +30,323 @@ public class SingleSetValidator : AbstractValidator<SetEntity, (ITenantContext T
     {
         // facts for all
 
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.BallPointsNotNegative,
-                FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
-                Enabled = true,
-                Type = FactType.Critical,
-                CheckAsync = (cancellationToken) => Task.FromResult(
-                    new FactResult
-                    {
-                        Message = SingleSetValidatorResource.ResourceManager.GetString(
-                            nameof(FactId.BallPointsNotNegative)) ?? string.Empty,
-                        Success = Model.HomeBallPoints >= 0 && Model.GuestBallPoints >= 0
-                    })
-            });
-
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.TieIsAllowed,
-                FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
-                Enabled = true,
-                Type = FactType.Error,
-                CheckAsync = async (cancellationToken) =>
-                {
-                    var factResult = new FactResult
-                    {
-                        Message =
-                            SingleSetValidatorResource.ResourceManager.GetString(
-                                nameof(FactId.TieIsAllowed)) ?? string.Empty,
-                        Success = true
-                    };
-
-                    if (Model.HomeBallPoints == Model.GuestBallPoints)
-                    {
-                        if (Model.IsTieBreak)
-                        {
-                            factResult.Success = Data.SetRule.PointsDiffToWinTiebreak == 0
-                                                 && (Model.HomeBallPoints > 0 || Model.GuestBallPoints > 0);
-                        }
-                        else
-                        {
-                            factResult.Success = Data.SetRule.PointsDiffToWinRegular == 0
-                                                 && (Model.HomeBallPoints > 0 || Model.GuestBallPoints > 0);
-                        }
-                    }
-
-                    return await Task.FromResult(factResult);
-                }
-            });
-
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.NumOfPointsToWinReached,
-                FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
-                Enabled = true,
-                Type = FactType.Error,
-                CheckAsync = (cancellationToken) => Task.FromResult(
-                    Model.IsTieBreak
-                        ? new FactResult
-                        {
-                            Message = string.Format(
-                                SingleSetValidatorResource.ResourceManager.GetString(
-                                    nameof(FactId.NumOfPointsToWinReached)) ?? string.Empty,
-                                Data.SetRule.NumOfPointsToWinTiebreak),
-                            Success = Model.HomeBallPoints >= Data.SetRule.NumOfPointsToWinTiebreak ||
-                                      Model.GuestBallPoints >= Data.SetRule.NumOfPointsToWinTiebreak
-                        }
-                        : new FactResult
-                        {
-                            Message = string.Format(
-                                SingleSetValidatorResource.ResourceManager.GetString(
-                                    nameof(FactId.NumOfPointsToWinReached)) ?? string.Empty,
-                                Data.SetRule.NumOfPointsToWinRegular),
-                            Success = Model.HomeBallPoints >= Data.SetRule.NumOfPointsToWinRegular ||
-                                      Model.GuestBallPoints >= Data.SetRule.NumOfPointsToWinRegular
-                        })
-            });
+        Facts.Add(BallPointsNotNegative());
+        Facts.Add(TieIsAllowed());
+        Facts.Add(NumOfPointsToWinReached());
 
         // facts for regular sets
 
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.RegularWinReachedWithOnePointAhead,
-                FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
-                Enabled = true,
-                Type = FactType.Error,
-                CheckAsync = async (cancellationToken) =>
-                {
-                    var factResult = new FactResult
-                    {
-                        Message = string.Format(
-                            SingleSetValidatorResource.ResourceManager.GetString(
-                                nameof(FactId.RegularWinReachedWithOnePointAhead)) ?? string.Empty,
-                            Data.SetRule.NumOfPointsToWinRegular, Data.SetRule.PointsDiffToWinRegular),
-                        Success = true
-                    };
-
-                    // separate rule for tie-break
-                    if (!Model.IsTieBreak && Data.SetRule.PointsDiffToWinRegular == 1)
-                    {
-                        factResult.Success =
-                            // One team exactly reached required points to win,
-                            // and the other must have less the needed difference
-                            (Model.HomeBallPoints == Data.SetRule.NumOfPointsToWinRegular
-                             && Model.GuestBallPoints < Model.HomeBallPoints)
-                            ||
-                            (Model.GuestBallPoints == Data.SetRule.NumOfPointsToWinRegular
-                             && Model.HomeBallPoints < Model.GuestBallPoints);
-                    }
-
-                    return await Task.FromResult(factResult);
-                }
-            });
-
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.RegularWinReachedWithTwoPlusPointsAhead,
-                FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
-                Enabled = true,
-                Type = FactType.Error,
-                CheckAsync = (cancellationToken) =>
-                {
-                    var factResult = new FactResult
-                    {
-                        Message = SingleSetValidatorResource.ResourceManager.GetString(
-                            nameof(FactId.RegularWinReachedWithTwoPlusPointsAhead)) ?? string.Empty,
-                        Success = true
-                    };
-
-                    // separate rule for tie-break
-                    if (!Model.IsTieBreak && Data.SetRule.PointsDiffToWinRegular > 1)
-                    {
-                        // Home team reached required points to win
-                        if (Model.HomeBallPoints == Data.SetRule.NumOfPointsToWinRegular &&
-                            Model.HomeBallPoints > Model.GuestBallPoints)
-                        {
-                            factResult.Success = Model.HomeBallPoints - Model.GuestBallPoints >=
-                                                 Data.SetRule.PointsDiffToWinRegular;
-                            factResult.Message = string.Format(factResult.Message ?? string.Empty,
-                                SingleSetValidatorResource.TextAtLeast,
-                                Data.SetRule.PointsDiffToWinRegular,
-                                string.Empty,
-                                Data.SetRule.NumOfPointsToWinRegular);
-                            return Task.FromResult(factResult);
-                        }
-
-                        // Guest team reached required points to win
-                        if (Model.GuestBallPoints == Data.SetRule.NumOfPointsToWinRegular &&
-                            Model.GuestBallPoints > Model.HomeBallPoints)
-                        {
-                            factResult.Success = Model.GuestBallPoints - Model.HomeBallPoints >=
-                                                 Data.SetRule.PointsDiffToWinRegular;
-                            factResult.Message = string.Format(factResult.Message ?? string.Empty,
-                                SingleSetValidatorResource.TextAtLeast,
-                                Data.SetRule.PointsDiffToWinRegular,
-                                string.Empty,
-                                Data.SetRule.NumOfPointsToWinRegular);
-
-                            return Task.FromResult(factResult);
-                        }
-
-                        // Minimum required ball points are exceeded
-                        if (Model.HomeBallPoints > Data.SetRule.NumOfPointsToWinRegular ||
-                            Model.GuestBallPoints > Data.SetRule.NumOfPointsToWinRegular)
-                        {
-                            factResult.Success = Math.Abs(Model.GuestBallPoints - Model.HomeBallPoints) ==
-                                                 Data.SetRule.PointsDiffToWinRegular;
-                            factResult.Message = string.Format(factResult.Message ?? string.Empty,
-                                SingleSetValidatorResource.TextExactly,
-                                Data.SetRule.PointsDiffToWinRegular,
-                                SingleSetValidatorResource.TextMoreThan,
-                                Data.SetRule.NumOfPointsToWinRegular);
-                        }
-                    }
-
-                    return Task.FromResult(factResult);
-                }
-            });
+        Facts.Add(RegularWinReachedWithOnePointAhead());
+        Facts.Add(RegularWinReachedWithTwoPlusPointsAhead());
 
         // facts for tie-break sets
 
-        Facts.Add(
-            new Fact<FactId>
+        Facts.Add(TieBreakWinReachedWithOnePointAhead());
+        Facts.Add(TieBreakWinReachedWithTwoPlusPointsAhead());
+    }
+
+    private Fact<FactId> TieBreakWinReachedWithTwoPlusPointsAhead()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.TieBreakWinReachedWithTwoPlusPointsAhead,
+            FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
+            Enabled = true,
+            Type = FactType.Error,
+            CheckAsync = (cancellationToken) => FactResult()
+        };
+
+        Task<FactResult> FactResult()
+        {
+            var factResult = new FactResult
             {
-                Id = FactId.TieBreakWinReachedWithOnePointAhead,
-                FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
-                Enabled = true,
-                Type = FactType.Error,
-                CheckAsync = async (cancellationToken) =>
+                Message = SingleSetValidatorResource.ResourceManager.GetString(
+                    nameof(FactId.TieBreakWinReachedWithTwoPlusPointsAhead)) ?? string.Empty,
+                Success = true
+            };
+
+            if (Model.IsTieBreak && Data.SetRule.PointsDiffToWinTiebreak > 1)
+            {
+                // Home team reached required points to win
+                if (Model.HomeBallPoints == Data.SetRule.NumOfPointsToWinTiebreak &&
+                    Model.HomeBallPoints > Model.GuestBallPoints)
                 {
-                    var factResult = new FactResult
+                    factResult.Success = Model.HomeBallPoints - Model.GuestBallPoints >=
+                                         Data.SetRule.PointsDiffToWinTiebreak;
+                    factResult.Message = string.Format(factResult.Message,
+                        SingleSetValidatorResource.TextAtLeast,
+                        Data.SetRule.PointsDiffToWinTiebreak,
+                        string.Empty,
+                        Data.SetRule.NumOfPointsToWinTiebreak);
+                    return Task.FromResult(factResult);
+                }
+
+                // Guest team reached required points to win
+                if (Model.GuestBallPoints == Data.SetRule.NumOfPointsToWinTiebreak &&
+                    Model.GuestBallPoints > Model.HomeBallPoints)
+                {
+                    factResult.Success = Model.GuestBallPoints - Model.HomeBallPoints >=
+                                         Data.SetRule.PointsDiffToWinTiebreak;
+                    factResult.Message = string.Format(factResult.Message,
+                        SingleSetValidatorResource.TextAtLeast,
+                        Data.SetRule.PointsDiffToWinTiebreak,
+                        string.Empty,
+                        Data.SetRule.NumOfPointsToWinTiebreak);
+
+                    return Task.FromResult(factResult);
+                }
+
+                // Minimum required ball points are exceeded
+                if (Model.HomeBallPoints > Data.SetRule.NumOfPointsToWinTiebreak ||
+                    Model.GuestBallPoints > Data.SetRule.NumOfPointsToWinTiebreak)
+                {
+                    factResult.Success = Math.Abs(Model.GuestBallPoints - Model.HomeBallPoints) ==
+                                         Data.SetRule.PointsDiffToWinTiebreak;
+                    // The difference in ball points must be {0} {1} if a team has {2} {3} ballpoints
+                    factResult.Message = string.Format(factResult.Message,
+                        SingleSetValidatorResource.TextExactly,
+                        Data.SetRule.PointsDiffToWinTiebreak,
+                        SingleSetValidatorResource.TextMoreThan,
+                        Data.SetRule.NumOfPointsToWinTiebreak);
+                }
+            }
+            return Task.FromResult(factResult);
+        }
+    }
+
+    private Fact<FactId> TieBreakWinReachedWithOnePointAhead()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.TieBreakWinReachedWithOnePointAhead,
+            FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
+            Enabled = true,
+            Type = FactType.Error,
+            CheckAsync = (cancellationToken) => FactResult()
+        };
+
+        Task<FactResult> FactResult()
+        {
+            var factResult = new FactResult
+            {
+                Message = string.Format(
+                    SingleSetValidatorResource.ResourceManager.GetString(
+                        nameof(FactId.TieBreakWinReachedWithOnePointAhead)) ?? string.Empty,
+                    Data.SetRule.NumOfPointsToWinTiebreak, Data.SetRule.PointsDiffToWinTiebreak),
+                Success = true
+            };
+
+            // separate rule for regular set
+            if (Model.IsTieBreak && Data.SetRule.PointsDiffToWinTiebreak == 1)
+            {
+                factResult.Success =
+                    // One team exactly reached required points to win,
+                    // and the other must have less the needed difference
+                    (Model.HomeBallPoints == Data.SetRule.NumOfPointsToWinTiebreak
+                     && Model.GuestBallPoints < Model.HomeBallPoints)
+                    ||
+                    (Model.GuestBallPoints == Data.SetRule.NumOfPointsToWinTiebreak
+                     && Model.HomeBallPoints < Model.GuestBallPoints);
+            }
+
+            return Task.FromResult(factResult);
+        }
+    }
+
+    private Fact<FactId> RegularWinReachedWithTwoPlusPointsAhead()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.RegularWinReachedWithTwoPlusPointsAhead,
+            FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
+            Enabled = true,
+            Type = FactType.Error,
+            CheckAsync = (cancellationToken) => FactResult()
+        };
+
+        Task<FactResult> FactResult()
+        {
+            var factResult = new FactResult
+            {
+                Message = SingleSetValidatorResource.ResourceManager.GetString(
+                    nameof(FactId.RegularWinReachedWithTwoPlusPointsAhead)) ?? string.Empty,
+                Success = true
+            };
+
+            // separate rule for tie-break
+            if (!Model.IsTieBreak && Data.SetRule.PointsDiffToWinRegular > 1)
+            {
+                // Home team reached required points to win
+                if (Model.HomeBallPoints == Data.SetRule.NumOfPointsToWinRegular &&
+                    Model.HomeBallPoints > Model.GuestBallPoints)
+                {
+                    factResult.Success = Model.HomeBallPoints - Model.GuestBallPoints >=
+                                         Data.SetRule.PointsDiffToWinRegular;
+                    factResult.Message = string.Format(factResult.Message,
+                        SingleSetValidatorResource.TextAtLeast,
+                        Data.SetRule.PointsDiffToWinRegular,
+                        string.Empty,
+                        Data.SetRule.NumOfPointsToWinRegular);
+                    return Task.FromResult(factResult);
+                }
+
+                // Guest team reached required points to win
+                if (Model.GuestBallPoints == Data.SetRule.NumOfPointsToWinRegular &&
+                    Model.GuestBallPoints > Model.HomeBallPoints)
+                {
+                    factResult.Success = Model.GuestBallPoints - Model.HomeBallPoints >=
+                                         Data.SetRule.PointsDiffToWinRegular;
+                    factResult.Message = string.Format(factResult.Message,
+                        SingleSetValidatorResource.TextAtLeast,
+                        Data.SetRule.PointsDiffToWinRegular,
+                        string.Empty,
+                        Data.SetRule.NumOfPointsToWinRegular);
+
+                    return Task.FromResult(factResult);
+                }
+
+                // Minimum required ball points are exceeded
+                if (Model.HomeBallPoints > Data.SetRule.NumOfPointsToWinRegular ||
+                    Model.GuestBallPoints > Data.SetRule.NumOfPointsToWinRegular)
+                {
+                    factResult.Success = Math.Abs(Model.GuestBallPoints - Model.HomeBallPoints) ==
+                                         Data.SetRule.PointsDiffToWinRegular;
+                    factResult.Message = string.Format(factResult.Message,
+                        SingleSetValidatorResource.TextExactly,
+                        Data.SetRule.PointsDiffToWinRegular,
+                        SingleSetValidatorResource.TextMoreThan,
+                        Data.SetRule.NumOfPointsToWinRegular);
+                }
+            }
+
+            return Task.FromResult(factResult);
+        }
+    }
+
+    private Fact<FactId> RegularWinReachedWithOnePointAhead()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.RegularWinReachedWithOnePointAhead,
+            FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
+            Enabled = true,
+            Type = FactType.Error,
+            CheckAsync = (cancellationToken) => FactResult()
+        };
+
+        Task<FactResult> FactResult()
+        {
+            var factResult = new FactResult
+            {
+                Message = string.Format(
+                    SingleSetValidatorResource.ResourceManager.GetString(
+                        nameof(FactId.RegularWinReachedWithOnePointAhead)) ?? string.Empty,
+                    Data.SetRule.NumOfPointsToWinRegular, Data.SetRule.PointsDiffToWinRegular),
+                Success = true
+            };
+
+            // separate rule for tie-break
+            if (!Model.IsTieBreak && Data.SetRule.PointsDiffToWinRegular == 1)
+            {
+                factResult.Success =
+                    // One team exactly reached required points to win,
+                    // and the other must have less the needed difference
+                    (Model.HomeBallPoints == Data.SetRule.NumOfPointsToWinRegular
+                     && Model.GuestBallPoints < Model.HomeBallPoints)
+                    ||
+                    (Model.GuestBallPoints == Data.SetRule.NumOfPointsToWinRegular
+                     && Model.HomeBallPoints < Model.GuestBallPoints);
+            }
+
+            return Task.FromResult(factResult);
+        }
+    }
+
+    private Fact<FactId> NumOfPointsToWinReached()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.NumOfPointsToWinReached,
+            FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
+            Enabled = true,
+            Type = FactType.Error,
+            CheckAsync = (cancellationToken) => Task.FromResult(
+                Model.IsTieBreak
+                    ? new FactResult
                     {
                         Message = string.Format(
                             SingleSetValidatorResource.ResourceManager.GetString(
-                                nameof(FactId.TieBreakWinReachedWithOnePointAhead)) ?? string.Empty,
-                            Data.SetRule.NumOfPointsToWinTiebreak, Data.SetRule.PointsDiffToWinTiebreak),
-                        Success = true
-                    };
-
-                    // separate rule for regular set
-                    if (Model.IsTieBreak && Data.SetRule.PointsDiffToWinTiebreak == 1)
-                    {
-                        factResult.Success =
-                            // One team exactly reached required points to win,
-                            // and the other must have less the needed difference
-                            (Model.HomeBallPoints == Data.SetRule.NumOfPointsToWinTiebreak
-                             && Model.GuestBallPoints < Model.HomeBallPoints)
-                            ||
-                            (Model.GuestBallPoints == Data.SetRule.NumOfPointsToWinTiebreak
-                             && Model.HomeBallPoints < Model.GuestBallPoints);
+                                nameof(FactId.NumOfPointsToWinReached)) ?? string.Empty,
+                            Data.SetRule.NumOfPointsToWinTiebreak),
+                        Success = Model.HomeBallPoints >= Data.SetRule.NumOfPointsToWinTiebreak ||
+                                  Model.GuestBallPoints >= Data.SetRule.NumOfPointsToWinTiebreak
                     }
+                    : new FactResult
+                    {
+                        Message = string.Format(
+                            SingleSetValidatorResource.ResourceManager.GetString(
+                                nameof(FactId.NumOfPointsToWinReached)) ?? string.Empty,
+                            Data.SetRule.NumOfPointsToWinRegular),
+                        Success = Model.HomeBallPoints >= Data.SetRule.NumOfPointsToWinRegular ||
+                                  Model.GuestBallPoints >= Data.SetRule.NumOfPointsToWinRegular
+                    })
+        };
+    }
 
-                    return await Task.FromResult(factResult);
-                }
-            });
+    private Fact<FactId> TieIsAllowed()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.TieIsAllowed,
+            FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
+            Enabled = true,
+            Type = FactType.Error,
+            CheckAsync = (cancellationToken) => FactResult()
+        };
 
-        Facts.Add(
-            new Fact<FactId>
+        Task<FactResult> FactResult()
+        {
+            var factResult = new FactResult
             {
-                Id = FactId.TieBreakWinReachedWithTwoPlusPointsAhead,
-                FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
-                Enabled = true,
-                Type = FactType.Error,
-                CheckAsync = (cancellationToken) =>
+                Message =
+                    SingleSetValidatorResource.ResourceManager.GetString(
+                        nameof(FactId.TieIsAllowed)) ?? string.Empty,
+                Success = true
+            };
+
+            if (Model.HomeBallPoints == Model.GuestBallPoints)
+            {
+                if (Model.IsTieBreak)
                 {
-                    var factResult = new FactResult
-                    {
-                        Message = SingleSetValidatorResource.ResourceManager.GetString(
-                            nameof(FactId.TieBreakWinReachedWithTwoPlusPointsAhead)) ?? string.Empty,
-                        Success = true
-                    };
-
-                    if (Model.IsTieBreak && Data.SetRule.PointsDiffToWinTiebreak > 1)
-                    {
-                        // Home team reached required points to win
-                        if (Model.HomeBallPoints == Data.SetRule.NumOfPointsToWinTiebreak &&
-                            Model.HomeBallPoints > Model.GuestBallPoints)
-                        {
-                            factResult.Success = Model.HomeBallPoints - Model.GuestBallPoints >=
-                                                 Data.SetRule.PointsDiffToWinTiebreak;
-                            factResult.Message = string.Format(factResult.Message ?? string.Empty,
-                                SingleSetValidatorResource.TextAtLeast,
-                                Data.SetRule.PointsDiffToWinTiebreak,
-                                string.Empty,
-                                Data.SetRule.NumOfPointsToWinTiebreak);
-                            return Task.FromResult(factResult);
-                        }
-
-                        // Guest team reached required points to win
-                        if (Model.GuestBallPoints == Data.SetRule.NumOfPointsToWinTiebreak &&
-                            Model.GuestBallPoints > Model.HomeBallPoints)
-                        {
-                            factResult.Success = Model.GuestBallPoints - Model.HomeBallPoints >=
-                                                 Data.SetRule.PointsDiffToWinTiebreak;
-                            factResult.Message = string.Format(factResult.Message ?? string.Empty,
-                                SingleSetValidatorResource.TextAtLeast,
-                                Data.SetRule.PointsDiffToWinTiebreak,
-                                string.Empty,
-                                Data.SetRule.NumOfPointsToWinTiebreak);
-
-                            return Task.FromResult(factResult);
-                        }
-
-                        // Minimum required ball points are exceeded
-                        if (Model.HomeBallPoints > Data.SetRule.NumOfPointsToWinTiebreak ||
-                            Model.GuestBallPoints > Data.SetRule.NumOfPointsToWinTiebreak)
-                        {
-                            factResult.Success = Math.Abs(Model.GuestBallPoints - Model.HomeBallPoints) ==
-                                                 Data.SetRule.PointsDiffToWinTiebreak;
-                            // The difference in ball points must be {0} {1} if a team has {2} {3} ballpoints
-                            factResult.Message = string.Format(factResult.Message ?? string.Empty,
-                                SingleSetValidatorResource.TextExactly,
-                                Data.SetRule.PointsDiffToWinTiebreak,
-                                SingleSetValidatorResource.TextMoreThan,
-                                Data.SetRule.NumOfPointsToWinTiebreak);
-                        }
-                    }
-                    return Task.FromResult(factResult);
+                    factResult.Success = Data.SetRule.PointsDiffToWinTiebreak == 0
+                                         && (Model.HomeBallPoints > 0 || Model.GuestBallPoints > 0);
                 }
-            });
+                else
+                {
+                    factResult.Success = Data.SetRule.PointsDiffToWinRegular == 0
+                                         && (Model.HomeBallPoints > 0 || Model.GuestBallPoints > 0);
+                }
+            }
+
+            return Task.FromResult(factResult);
+        }
+    }
+
+    private Fact<FactId> BallPointsNotNegative()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.BallPointsNotNegative,
+            FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
+            Enabled = true,
+            Type = FactType.Critical,
+            CheckAsync = (cancellationToken) => Task.FromResult(
+                new FactResult
+                {
+                    Message = SingleSetValidatorResource.ResourceManager.GetString(
+                        nameof(FactId.BallPointsNotNegative)) ?? string.Empty,
+                    Success = Model is { HomeBallPoints: >= 0, GuestBallPoints: >= 0 }
+                })
+        };
     }
 }

--- a/TournamentManager/TournamentManager/ModelValidators/SingleSetValidatorResource.Designer.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/SingleSetValidatorResource.Designer.cs
@@ -19,7 +19,7 @@ namespace TournamentManager.ModelValidators {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SingleSetValidatorResource {
@@ -93,6 +93,15 @@ namespace TournamentManager.ModelValidators {
         internal static string RegularWinReachedWithTwoPlusPointsAhead {
             get {
                 return ResourceManager.GetString("RegularWinReachedWithTwoPlusPointsAhead", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Allowed set points are {0}.
+        /// </summary>
+        internal static string SetPointsAreValid {
+            get {
+                return ResourceManager.GetString("SetPointsAreValid", resourceCulture);
             }
         }
         

--- a/TournamentManager/TournamentManager/ModelValidators/SingleSetValidatorResource.de.resx
+++ b/TournamentManager/TournamentManager/ModelValidators/SingleSetValidatorResource.de.resx
@@ -129,6 +129,9 @@
   <data name="RegularWinReachedWithTwoPlusPointsAhead" xml:space="preserve">
     <value>Die Differenz der Ballpunkte muss {0} {1} sein, wenn ein Team {2} {3} Ballpunkte erreicht</value>
   </data>
+  <data name="SetPointsAreValid" xml:space="preserve">
+    <value>Erlaubte Satzpunkte sind {0}</value>
+  </data>
   <data name="TextAtLeast" xml:space="preserve">
     <value>mindestens</value>
   </data>

--- a/TournamentManager/TournamentManager/ModelValidators/SingleSetValidatorResource.resx
+++ b/TournamentManager/TournamentManager/ModelValidators/SingleSetValidatorResource.resx
@@ -129,6 +129,9 @@
   <data name="RegularWinReachedWithTwoPlusPointsAhead" xml:space="preserve">
     <value>The difference in ball points must be {0} {1} if a team has {2} {3} ball points</value>
   </data>
+  <data name="SetPointsAreValid" xml:space="preserve">
+    <value>Allowed set points are {0}</value>
+  </data>
   <data name="TextAtLeast" xml:space="preserve">
     <value>at least</value>
   </data>

--- a/TournamentManager/TournamentManager/ModelValidators/TeamValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/TeamValidator.cs
@@ -22,99 +22,117 @@ public class TeamValidator : AbstractValidator<TeamEntity, ITenantContext, TeamV
 
     private void CreateFacts()
     {
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.TeamNameIsSet,
-                FieldNames = new[] { nameof(Model.Name) },
-                Enabled = true,
-                Type = FactType.Critical,
-                CheckAsync = (cancellationToken) => Task.FromResult(
-                    new FactResult
-                    {
-                        Message = TeamValidatorResource.ResourceManager.GetString(
-                            nameof(FactId.TeamNameIsSet)) ?? string.Empty,
-                        Success = !string.IsNullOrWhiteSpace(Model.Name)
-                    })
-            });
+        Facts.Add(TeamNameIsSet());
+        Facts.Add(TeamNameIsUnique());
+        Facts.Add(MatchDayOfWeekAndTimeIsSet());
+        Facts.Add(DayOfWeekWithinRange());
+        Facts.Add(MatchTimeWithinRange());
+    }
 
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.TeamNameIsUnique,
-                FieldNames = new[] { nameof(Model.Name) },
-                Enabled = !string.IsNullOrEmpty(Model.Name),
-                Type = FactType.Critical,
-                CheckAsync = async (cancellationToken) =>
+    private Fact<FactId> MatchTimeWithinRange()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.MatchTimeWithinRange,
+            FieldNames = new[] {nameof(Model.MatchTime)},
+            Enabled = Data.TournamentContext.TeamRuleSet.HomeMatchTime.MustBeSet,
+            Type = FactType.Warning,
+            CheckAsync = (cancellationToken) => Task.FromResult(
+                new FactResult
                 {
-                    var teamName = await Data.DbContext.AppDb.TeamRepository.TeamNameExistsAsync(Model, cancellationToken);
-                    return new FactResult
-                    {
-                        Message = string.Format(TeamValidatorResource.ResourceManager.GetString(
-                            nameof(FactId.TeamNameIsUnique)) ?? string.Empty, teamName),
-                        Success = string.IsNullOrEmpty(teamName)
-                    };
-                }
-            });
+                    Message = string.Format(
+                        TeamValidatorResource.ResourceManager.GetString(
+                            nameof(FactId.MatchTimeWithinRange)) ?? string.Empty,
+                        Data.TournamentContext.FixtureRuleSet.RegularMatchStartTime.MinDayTime.ToShortTimeString(),
+                        Data.TournamentContext.FixtureRuleSet.RegularMatchStartTime.MaxDayTime.ToShortTimeString()),
+                    // regular start time is given in local time
+                    Success = Model.MatchTime.HasValue && Model.MatchTime >= Data.TournamentContext.FixtureRuleSet.RegularMatchStartTime.MinDayTime &&
+                              Model.MatchTime <= Data.TournamentContext.FixtureRuleSet.RegularMatchStartTime.MaxDayTime
+                })
+        };
+    }
 
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.MatchDayOfWeekAndTimeIsSet,
-                FieldNames = new[] {nameof(Model.MatchDayOfWeek), nameof(Model.MatchTime)},
-                Enabled = Data.TournamentContext.TeamRuleSet.HomeMatchTime is { IsEditable: true },
-                Type = FactType.Critical,
-                CheckAsync = (cancellationToken) => Task.FromResult(
-                    new FactResult
-                    {
-                        Message = TeamValidatorResource.ResourceManager.GetString(
-                            nameof(FactId.MatchDayOfWeekAndTimeIsSet)) ?? string.Empty,
-                        Success = (Data.TournamentContext.TeamRuleSet.HomeMatchTime.MustBeSet && Model is { MatchDayOfWeek: not null, MatchTime: not null })
-                            || (!Data.TournamentContext.TeamRuleSet.HomeMatchTime.MustBeSet && Model is { MatchDayOfWeek: null, MatchTime: null } or { MatchDayOfWeek: not null, MatchTime: not null })
-                    })
-            });
+    private Fact<FactId> DayOfWeekWithinRange()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.DayOfWeekWithinRange,
+            FieldNames = new[] {nameof(Model.MatchDayOfWeek)},
+            Enabled = Data.TournamentContext.TeamRuleSet.HomeMatchTime is { IsEditable: true, MustBeSet: true },
+            Type = Data.TournamentContext.TeamRuleSet.HomeMatchTime.ErrorIfNotInDaysOfWeekRange
+                ? FactType.Error
+                : FactType.Warning,
+            CheckAsync = (cancellationToken) => Task.FromResult(
+                new FactResult
+                {
+                    Message = string.Format(TeamValidatorResource.ResourceManager.GetString(
+                            nameof(FactId.DayOfWeekWithinRange)) ?? string.Empty,
+                        Data.TournamentContext.TeamRuleSet.HomeMatchTime.ErrorIfNotInDaysOfWeekRange
+                            ? TeamValidatorResource.required
+                            : TeamValidatorResource.recommended),
+                    Success = Data.TournamentContext.TeamRuleSet.HomeMatchTime.DaysOfWeekRange.Select(dow => (int?) dow).ToList()
+                        .Contains(Model.MatchDayOfWeek)
+                })
+        };
+    }
 
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.DayOfWeekWithinRange,
-                FieldNames = new[] {nameof(Model.MatchDayOfWeek)},
-                Enabled = Data.TournamentContext.TeamRuleSet.HomeMatchTime is { IsEditable: true, MustBeSet: true },
-                Type = Data.TournamentContext.TeamRuleSet.HomeMatchTime.ErrorIfNotInDaysOfWeekRange
-                    ? FactType.Error
-                    : FactType.Warning,
-                CheckAsync = (cancellationToken) => Task.FromResult(
-                    new FactResult
-                    {
-                        Message = string.Format(TeamValidatorResource.ResourceManager.GetString(
-                                nameof(FactId.DayOfWeekWithinRange)) ?? string.Empty,
-                            Data.TournamentContext.TeamRuleSet.HomeMatchTime.ErrorIfNotInDaysOfWeekRange
-                                ? TeamValidatorResource.required
-                                : TeamValidatorResource.recommended),
-                        Success = Data.TournamentContext.TeamRuleSet.HomeMatchTime.DaysOfWeekRange.Select(dow => (int?) dow).ToList()
-                            .Contains(Model.MatchDayOfWeek)
-                    })
-            });
+    private Fact<FactId> MatchDayOfWeekAndTimeIsSet()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.MatchDayOfWeekAndTimeIsSet,
+            FieldNames = new[] {nameof(Model.MatchDayOfWeek), nameof(Model.MatchTime)},
+            Enabled = Data.TournamentContext.TeamRuleSet.HomeMatchTime is { IsEditable: true },
+            Type = FactType.Critical,
+            CheckAsync = (cancellationToken) => Task.FromResult(
+                new FactResult
+                {
+                    Message = TeamValidatorResource.ResourceManager.GetString(
+                        nameof(FactId.MatchDayOfWeekAndTimeIsSet)) ?? string.Empty,
+                    Success = (Data.TournamentContext.TeamRuleSet.HomeMatchTime.MustBeSet && Model is { MatchDayOfWeek: not null, MatchTime: not null })
+                              || (!Data.TournamentContext.TeamRuleSet.HomeMatchTime.MustBeSet && Model is { MatchDayOfWeek: null, MatchTime: null } or { MatchDayOfWeek: not null, MatchTime: not null })
+                })
+        };
+    }
 
-        Facts.Add(
-            new Fact<FactId>
+    private Fact<FactId> TeamNameIsUnique()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.TeamNameIsUnique,
+            FieldNames = new[] { nameof(Model.Name) },
+            Enabled = !string.IsNullOrEmpty(Model.Name),
+            Type = FactType.Critical,
+            CheckAsync = FactResult
+        };
+
+        async Task<FactResult> FactResult(CancellationToken cancellationToken)
+        {
+            var teamName = await Data.DbContext.AppDb.TeamRepository.TeamNameExistsAsync(Model, cancellationToken);
+            return new FactResult
             {
-                Id = FactId.MatchTimeWithinRange,
-                FieldNames = new[] {nameof(Model.MatchTime)},
-                Enabled = Data.TournamentContext.TeamRuleSet.HomeMatchTime.MustBeSet,
-                Type = FactType.Warning,
-                CheckAsync = (cancellationToken) => Task.FromResult(
-                    new FactResult
-                    {
-                        Message = string.Format(
-                            TeamValidatorResource.ResourceManager.GetString(
-                                nameof(FactId.MatchTimeWithinRange)) ?? string.Empty,
-                            Data.TournamentContext.FixtureRuleSet.RegularMatchStartTime.MinDayTime.ToShortTimeString(),
-                            Data.TournamentContext.FixtureRuleSet.RegularMatchStartTime.MaxDayTime.ToShortTimeString()),
-                        // regular start time is given in local time
-                        Success = Model.MatchTime.HasValue && Model.MatchTime >= Data.TournamentContext.FixtureRuleSet.RegularMatchStartTime.MinDayTime &&
-                                  Model.MatchTime <= Data.TournamentContext.FixtureRuleSet.RegularMatchStartTime.MaxDayTime
-                    })
-            });
+                Message = string.Format(TeamValidatorResource.ResourceManager.GetString(
+                    nameof(FactId.TeamNameIsUnique)) ?? string.Empty, teamName),
+                Success = string.IsNullOrEmpty(teamName)
+            };
+        }
+    }
+
+    private Fact<FactId> TeamNameIsSet()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.TeamNameIsSet,
+            FieldNames = new[] { nameof(Model.Name) },
+            Enabled = true,
+            Type = FactType.Critical,
+            CheckAsync = (cancellationToken) => Task.FromResult(
+                new FactResult
+                {
+                    Message = TeamValidatorResource.ResourceManager.GetString(
+                        nameof(FactId.TeamNameIsSet)) ?? string.Empty,
+                    Success = !string.IsNullOrWhiteSpace(Model.Name)
+                })
+        };
     }
 }

--- a/TournamentManager/TournamentManager/ModelValidators/TeamVenueValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/TeamVenueValidator.cs
@@ -18,38 +18,45 @@ public class TeamVenueValidator : AbstractValidator<TeamEntity, ITenantContext, 
 
     private void CreateFacts()
     {
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.VenueIsSetIfRequired,
-                FieldNames = new[] {nameof(Model.VenueId)},
-                Enabled = true,
-                Type = FactType.Critical,
-                CheckAsync = (cancellationToken) => Task.FromResult(
-                    new FactResult
-                    {
-                        Message = TeamVenueValidatorResource.ResourceManager.GetString(
-                                nameof(FactId.VenueIsSetIfRequired)) ?? string.Empty,
-                        // Venue is set, if required or venue has any value if not required
-                        Success = (Model.VenueId.HasValue && Data.TournamentContext.TeamRuleSet.HomeVenue.MustBeSet)
-                            || (!Data.TournamentContext.TeamRuleSet.HomeVenue.MustBeSet)
-                    })
-            });
+        Facts.Add(VenueIsSetIfRequired());
+        Facts.Add(VenueIsValid());
+    }
 
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.VenueIsValid,
-                FieldNames = new[] {nameof(Model.VenueId)},
-                Enabled = Model.VenueId.HasValue,
-                Type = FactType.Critical,
-                CheckAsync = async (cancellationToken) => new FactResult {
+    private Fact<FactId> VenueIsValid()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.VenueIsValid,
+            FieldNames = new[] {nameof(Model.VenueId)},
+            Enabled = Model.VenueId.HasValue,
+            Type = FactType.Critical,
+            CheckAsync = async (cancellationToken) => new FactResult {
+                Message = TeamVenueValidatorResource.ResourceManager.GetString(
+                    nameof(FactId.VenueIsValid)) ?? string.Empty,
+                Success = Model.VenueId.HasValue &&
+                          await Data.DbContext.AppDb.VenueRepository.IsValidVenueIdAsync(Model.VenueId,
+                              cancellationToken)
+            }
+        };
+    }
+
+    private Fact<FactId> VenueIsSetIfRequired()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.VenueIsSetIfRequired,
+            FieldNames = new[] {nameof(Model.VenueId)},
+            Enabled = true,
+            Type = FactType.Critical,
+            CheckAsync = (cancellationToken) => Task.FromResult(
+                new FactResult
+                {
                     Message = TeamVenueValidatorResource.ResourceManager.GetString(
-                            nameof(FactId.VenueIsValid)) ?? string.Empty,
-                    Success = Model.VenueId.HasValue &&
-                              await Data.DbContext.AppDb.VenueRepository.IsValidVenueIdAsync(Model.VenueId,
-                                  cancellationToken)
-                }
-            });
+                        nameof(FactId.VenueIsSetIfRequired)) ?? string.Empty,
+                    // Venue is set, if required or venue has any value if not required
+                    Success = (Model.VenueId.HasValue && Data.TournamentContext.TeamRuleSet.HomeVenue.MustBeSet)
+                              || (!Data.TournamentContext.TeamRuleSet.HomeVenue.MustBeSet)
+                })
+        };
     }
 }

--- a/TournamentManager/TournamentManager/ModelValidators/VenueValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/VenueValidator.cs
@@ -19,7 +19,7 @@ public class VenueValidator : AbstractValidator<VenueEntity, (GoogleGeo.GeoRespo
     /// CTOR.
     /// </summary>
     /// <param name="model"></param>
-    /// <param name="data">A <see cref="ValueTuple"/> with <see cref="GoogleGeo.GeoLocation"/> (may be NULL) and and <see cref="IList{T}"/> of <see cref="VenueDistanceResultRow"/> (may be empty).</param>
+    /// <param name="data">A <see cref="ValueTuple"/> with <see cref="GoogleGeo.GeoLocation"/> (maybe NULL) and <see cref="IList{T}"/> of <see cref="VenueDistanceResultRow"/> (maybe empty).</param>
     public VenueValidator(VenueEntity model, (GoogleGeo.GeoResponse GeoResponse, IList<VenueDistanceResultRow> VenueDistanceList) data) : base(model, data)
     {
         CreateFacts();
@@ -27,92 +27,110 @@ public class VenueValidator : AbstractValidator<VenueEntity, (GoogleGeo.GeoRespo
 
     private void CreateFacts()
     {
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.NameIsSet,
-                FieldNames = new[] { nameof(Model.Name) },
-                Enabled = true,
-                Type = FactType.Error,
-                CheckAsync = (cancellationToken) => Task.FromResult(
-                    new FactResult
-                    {
-                        Message = VenueValidatorResource.NameIsSet,
-                        Success = !string.IsNullOrWhiteSpace(Model.Name)
-                    })
-            });
+        Facts.Add(NameIsSet());
+        Facts.Add(AddressFieldsAreSet());
+        Facts.Add(CanBeLocated());
+        Facts.Add(LocationIsPrecise());
+        Facts.Add(NotExistingGeoLocation());
+    }
 
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.AddressFieldsAreSet,
-                FieldNames = new[] { nameof(Model.PostalCode), nameof(Model.City), nameof(Model.Street) },
-                Enabled = true,
-                Type = FactType.Error,
-                CheckAsync = (cancellationToken) => Task.FromResult(
-                    new FactResult
-                    {
-                        Message = VenueValidatorResource.AddressFieldsAreSet,
-                        Success = new[] {Model.PostalCode, Model.City, Model.Street}.All(f => !string.IsNullOrWhiteSpace(f))
-                    })
-            });
+    private Fact<FactId> NotExistingGeoLocation()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.NotExistingGeoLocation,
+            FieldNames = new[] { nameof(Model.Name) },
+            Enabled = Data.GeoResponse is { Success: true, Found: true },
+            Type = FactType.Warning,
+            CheckAsync = cancellationToken => FactResult()
+        };
 
-        Facts.Add(
-            new Fact<FactId>
+        Task<FactResult> FactResult()
+        {
+            var result = new FactResult
             {
-                Id = FactId.CanBeLocated,
-                FieldNames = new[] { nameof(Model.PostalCode), nameof(Model.City), nameof(Model.Street) },
-                Enabled = Data.GeoResponse.Success,
-                Type = FactType.Warning,
-                CheckAsync = (cancellationToken) => Task.FromResult(
-                    new FactResult
-                    {
-                        Message = VenueValidatorResource.CanBeLocated,
-                        Success = Data.GeoResponse.Found
-                    })
-            });
-
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.LocationIsPrecise,
-                FieldNames = new[] { nameof(Model.PostalCode), nameof(Model.City), nameof(Model.Street) },
-                Enabled = Data.GeoResponse.Success && Data.GeoResponse.Found,
-                Type = FactType.Warning,
-                CheckAsync = (cancellationToken) => Task.FromResult(
-                    new FactResult
-                    {
-                        Message = VenueValidatorResource.LocationIsPrecise,
-                        Success = !new[] {GoogleGeo.LocationType.Approximate, GoogleGeo.LocationType.GeometricCenter, GoogleGeo.LocationType.RangeInterpolated}.Contains(Data.GeoResponse.GeoLocation.LocationType)
-                    })
-            });
-
-        Facts.Add(
-            new Fact<FactId>
-            {
-                Id = FactId.NotExistingGeoLocation,
-                FieldNames = new[] { nameof(Model.Name) },
-                Enabled = Data.GeoResponse.Success && Data.GeoResponse.Found,
-                Type = FactType.Warning,
-                CheckAsync = cancellationToken =>
-                {
-                    var result = new FactResult
-                    {
-                        Message = VenueValidatorResource.NotExistingGeoLocation,
-                        Success = true
-                    };
+                Message = VenueValidatorResource.NotExistingGeoLocation,
+                Success = true
+            };
                         
-                    // If the list contains other venues close-by then the current one, then create a warning
-                    if (Data.VenueDistanceList.Any(v => Model.IsNew || v.Id != Model.Id))
-                    {
-                        // express maximum distance in meters, rounded to next 100
-                        var max = (int) (Math.Round(Data.VenueDistanceList.Max(v => v.Distance),1) * 1000);
-                        result.Message = string.Format(VenueValidatorResource.NotExistingGeoLocation, max);
-                        result.Success = false;
-                    }
+            // If the list contains other venues close-by then the current one, then create a warning
+            if (Data.VenueDistanceList.Any(v => Model.IsNew || v.Id != Model.Id))
+            {
+                // express maximum distance in meters, rounded to next 100
+                var max = (int) (Math.Round(Data.VenueDistanceList.Max(v => v.Distance),1) * 1000);
+                result.Message = string.Format(VenueValidatorResource.NotExistingGeoLocation, max);
+                result.Success = false;
+            }
 
-                    return Task.FromResult(result);
-                }
-            });
+            return Task.FromResult(result);
+        }
+    }
+
+    private Fact<FactId> LocationIsPrecise()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.LocationIsPrecise,
+            FieldNames = new[] { nameof(Model.PostalCode), nameof(Model.City), nameof(Model.Street) },
+            Enabled = Data.GeoResponse is { Success: true, Found: true },
+            Type = FactType.Warning,
+            CheckAsync = (cancellationToken) => Task.FromResult(
+                new FactResult
+                {
+                    Message = VenueValidatorResource.LocationIsPrecise,
+                    Success = !new[] {GoogleGeo.LocationType.Approximate, GoogleGeo.LocationType.GeometricCenter, GoogleGeo.LocationType.RangeInterpolated}.Contains(Data.GeoResponse.GeoLocation.LocationType)
+                })
+        };
+    }
+
+    private Fact<FactId> CanBeLocated()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.CanBeLocated,
+            FieldNames = new[] { nameof(Model.PostalCode), nameof(Model.City), nameof(Model.Street) },
+            Enabled = Data.GeoResponse.Success,
+            Type = FactType.Warning,
+            CheckAsync = (cancellationToken) => Task.FromResult(
+                new FactResult
+                {
+                    Message = VenueValidatorResource.CanBeLocated,
+                    Success = Data.GeoResponse.Found
+                })
+        };
+    }
+
+    private Fact<FactId> AddressFieldsAreSet()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.AddressFieldsAreSet,
+            FieldNames = new[] { nameof(Model.PostalCode), nameof(Model.City), nameof(Model.Street) },
+            Enabled = true,
+            Type = FactType.Error,
+            CheckAsync = (cancellationToken) => Task.FromResult(
+                new FactResult
+                {
+                    Message = VenueValidatorResource.AddressFieldsAreSet,
+                    Success = new[] {Model.PostalCode, Model.City, Model.Street}.All(f => !string.IsNullOrWhiteSpace(f))
+                })
+        };
+    }
+
+    private Fact<FactId> NameIsSet()
+    {
+        return new Fact<FactId>
+        {
+            Id = FactId.NameIsSet,
+            FieldNames = new[] { nameof(Model.Name) },
+            Enabled = true,
+            Type = FactType.Error,
+            CheckAsync = (cancellationToken) => Task.FromResult(
+                new FactResult
+                {
+                    Message = VenueValidatorResource.NameIsSet,
+                    Success = !string.IsNullOrWhiteSpace(Model.Name)
+                })
+        };
     }
 }

--- a/TournamentManager/TournamentManager/Plan/MatchScheduler.cs
+++ b/TournamentManager/TournamentManager/Plan/MatchScheduler.cs
@@ -152,10 +152,7 @@ internal class MatchScheduler
         // Matches in the same turnCombinations can even take place at the same time.
         var datesFound = GetMatchDatesForTurn(roundLeg, turn, combinations, tournamentMatches);
         _logger.LogDebug("Found dates for combination: {dates}",
-            string.Join(", ",
-                    datesFound.OrderBy(bd => bd?.MatchStartTime)
-                        .Select(bd => bd?.MatchStartTime.ToShortDateString() ?? "(null)"))
-                .Trim(',', ' '));
+            string.Join(", ", datesFound.Select(bd => bd?.MatchStartTime.ToShortDateString() ?? "(null)")).Trim(',', ' '));
 
         // datesFound contains calculated dates in the same sequence as turn combinations,
         // so the index can be used for both.


### PR DESCRIPTION
* Rename `EnterResultViewModel.Sets` to `EnterResultViewModel.BallPoints`
* Add `OverruleResultPolicy`
* Add `Match.OverruleResult(...)` controller action
* Update `EnterResultViewModel`
* Update notification email to reflect overruling
* Add `ConfigureFacts` to configure validators depending on default / overrule validation
* Add unit test for new validator methods
