### PR TITLE
Implement removing existing match results

### DIFF
--- a/League/BackgroundTasks/RankingUpdateTask.cs
+++ b/League/BackgroundTasks/RankingUpdateTask.cs
@@ -67,8 +67,8 @@ public class RankingUpdateTask : IBackgroundTask
     public long? RoundId { get; set; }
 
     /// <summary>
-    /// If set to <see langword="true"/>, ranking tables and ranking charts will updated,
-    /// never mind whether <see cref="MatchEntity.ModifiedOn"/> &gt; <see cref="RankingEntity.CreatedOn"/> or not.
+    /// If set to <see langword="true"/>, ranking tables and ranking charts will be updated,
+    /// never mind whether <see cref="MatchEntity.ModifiedOn"/> is later than <see cref="RankingEntity.CreatedOn"/> or not.
     /// </summary>
     public bool EnforceUpdate { get; set; }
 

--- a/League/Templates/Email/Localization/EmailResource.de.resx
+++ b/League/Templates/Email/Localization/EmailResource.de.resx
@@ -123,7 +123,7 @@
   </data>
   <data name="Ball points" xml:space="preserve">
     <value>Ballpunkte</value>
-    <comment>ResultEntered</comment>
+    <comment>ResultEntered, ResultRemoved</comment>
   </data>
   <data name="Bank name" xml:space="preserve">
     <value>Name der Bank</value>
@@ -171,7 +171,7 @@
   </data>
   <data name="End of match" xml:space="preserve">
     <value>Spielende</value>
-    <comment>ResultEntered</comment>
+    <comment>ResultEntered, ResultRemoved</comment>
   </data>
   <data name="Fixture change for team '{0}'" xml:space="preserve">
     <value>Spielplanänderung für Team '{0}'</value>
@@ -195,19 +195,27 @@
   </data>
   <data name="Match day of {0}" xml:space="preserve">
     <value>Spieltag {0}</value>
-    <comment>ResultEntered</comment>
+    <comment>ResultEntered, ResultRemoved</comment>
   </data>
   <data name="Match day of {0}, played on {1}" xml:space="preserve">
     <value>Spieltag {0}, gespielt am {1}</value>
-    <comment>ResultEntered</comment>
+    <comment>ResultEntered, ResultRemoved</comment>
   </data>
   <data name="Match points" xml:space="preserve">
     <value>Spielpunkte</value>
-    <comment>ResultEntered</comment>
+    <comment>ResultEntered, ResultRemoved</comment>
   </data>
   <data name="Match result '{0}' vs. '{1}'" xml:space="preserve">
     <value>Spielergebnis '{0}' gg. '{1}'</value>
-    <comment>ResultEnterdCreator</comment>
+    <comment>ResultEnteredCreator</comment>
+  </data>
+  <data name="Match result removed" xml:space="preserve">
+    <value>Spielergebnis entfernt</value>
+    <comment>ResultEntered, ResultRemoved</comment>
+  </data>
+  <data name="Match result removed: '{0}' vs. '{1}'" xml:space="preserve">
+    <value>Spielergebnis entfernt: '{0}' vs. '{1}'</value>
+    <comment>ResultEnteredCreator</comment>
   </data>
   <data name="Message" xml:space="preserve">
     <value>Nachricht</value>
@@ -235,7 +243,7 @@
   </data>
   <data name="No sets" xml:space="preserve">
     <value>Keine Sätze</value>
-    <comment>ResultEntered</comment>
+    <comment>ResultEntered, ResultRemoved</comment>
   </data>
   <data name="Number of changes" xml:space="preserve">
     <value>Anzahl Änderungen</value>
@@ -271,7 +279,7 @@
   </data>
   <data name="Remarks" xml:space="preserve">
     <value>Anmerkungen</value>
-    <comment>ResultEntered</comment>
+    <comment>ResultEntered, ResultRemoved</comment>
   </data>
   <data name="Replacement fixture date" xml:space="preserve">
     <value>Neuer Ausweichspieltag</value>
@@ -283,7 +291,7 @@
   </data>
   <data name="Result" xml:space="preserve">
     <value>Ergebnis</value>
-    <comment>ResultEntered</comment>
+    <comment>ResultEntered, ResultRemoved</comment>
   </data>
   <data name="Season fixture date" xml:space="preserve">
     <value>Spieldatum lt. Saisonplan</value>
@@ -299,11 +307,11 @@
   </data>
   <data name="Set #{0}" xml:space="preserve">
     <value>{0}. Satz</value>
-    <comment>ResultEntered</comment>
+    <comment>ResultEntered, ResultRemoved</comment>
   </data>
   <data name="Set points" xml:space="preserve">
     <value>Satzpunkte</value>
-    <comment>ResultEntered</comment>
+    <comment>ResultEntered, ResultRemoved</comment>
   </data>
   <data name="Sporting greetings" xml:space="preserve">
     <value>Sportliche Grüße</value>
@@ -311,7 +319,7 @@
   </data>
   <data name="Start of match" xml:space="preserve">
     <value>Spielbeginn</value>
-    <comment>ResultEntered</comment>
+    <comment>ResultEntered, ResultRemoved</comment>
   </data>
   <data name="Subject" xml:space="preserve">
     <value>Betreff</value>
@@ -340,6 +348,10 @@
   <data name="The confirmation link can be used until" xml:space="preserve">
     <value>Der Bestätigungslink kann verwendet werden bis zum</value>
     <comment>PleaseConfirmEmail</comment>
+  </data>
+  <data name="The match went back to fixtures" xml:space="preserve">
+    <value>Das Spiel steht wieder im Spielplan</value>
+    <comment>ResultRemoved</comment>
   </data>
   <data name="The recovery code can be used once until" xml:space="preserve">
     <value>Der Schlüssel kann einmal verwendet werden bis zum</value>

--- a/League/Templates/Email/ResultRemovedTxt.tpl
+++ b/League/Templates/Email/ResultRemovedTxt.tpl
@@ -1,0 +1,54 @@
+﻿
+{{ org_ctx.Name }} ({{ model.RoundDescription }})
+{{ model.HomeTeamName }} : {{ model.GuestTeamName }}
+
+{{ plannedstart = ndate.to_zoned_time (model.Match.OrigPlannedStart ? model.Match.OrigPlannedStart : model.Match.PlannedStart) ~}}
+{{ realstart = ndate.to_zoned_time model.Match.RealStart ~}}
+{{ realend = ndate.to_zoned_time model.Match.RealEnd ~}}
+{{ if realstart == plannedstart ~}}
+    {{~ L "Match day of {0}" (ndate.format realstart "d") }} {{ realstart | ndate.tz_abbr }}
+{{ else ~}}
+    {{~ L "Match day of {0}, played on {1}" (ndate.format plannedstart "d") (ndate.format realstart "d") }} {{ realstart | ndate.tz_abbr }}
+{{ end ~}}
+
+#### {{ L "Match result removed" }} ####
+
+{{ if model.Match.Sets.size > 0 ~}}
+    {{~ L "Ball points" }} / {{ L "Set points" }}
+{{ else ~}}
+
+    {{~ L "No sets" ~}}
+{{ end ~}}
+{{ i = 0 }}
+{{ points = { homeball: 0, guestball: 0, homeset: 0, guestset: 0 } ~}}
+{{for set in model.Match.Sets ~}} 
+    {{~ points.homeball = points.homeball + set.HomeBallPoints ~}}
+    {{~ points.guestball = points.guestball + set.GuestBallPoints ~}}
+    {{~ points.homeset = points.homeset + set.HomeSetPoints ~}}
+    {{~ points.guestset = points.guestset + set.GuestSetPoints ~}}
+    {{~ i = i + 1 ~}}
+    {{~ L "Set #{0}" i }}:  {{ set.HomeBallPoints | string.pad_left 2 }} : {{ set.GuestBallPoints | string.pad_right 2 }}  / {{ set.HomeSetPoints | string.pad_left 2 }} : {{ set.GuestSetPoints | string.pad_right 2 }}
+{{ end ~}}
+
+{{ padright = [ L "Ball points", L "Set points", L "Match points" ] | array.map "size" | array.sort | array.last ~}}
+{{ L "Ball points" | string.pad_right padright }}: {{ points.homeball | string.pad_left 3 }} : {{ points.guestball }}
+{{ L "Set points" | string.pad_right padright }}: {{ points.homeset | string.pad_left 3 }} : {{ points.guestset }}
+{{ L "Match points" | string.pad_right padright }}: {{ model.Match.HomePoints | string.pad_left 3 }} : {{ model.Match.GuestPoints }}
+
+{{ padright = [ L "Start of match", L "End of match" ] | array.map "size" | array.sort | array.last ~}}
+{{ L "Start of match" | string.pad_right padright }}: {{ ndate.format realstart "t" }} {{ realstart | ndate.tz_abbr }}
+{{ L "End of match" | string.pad_right padright }}: {{ ndate.format realend "t" }} {{ realend | ndate.tz_abbr }}
+
+{{ if (model.Match.Remarks | string.strip | string.size) > 2 ~}}
+    {{~ L "Remarks" }}:
+    {{~ model.Match.Remarks }}
+
+{{ end ~}}
+{{ L "The match went back to fixtures"}}.
+{{ L "Changes were submitted by" }} {{ model.Username ? model.Username : "?" }}.
+{{ L "This notification has been sent to the contact persons and players of the teams" }}.
+
+{{ org_ctx.Name }}
+
+
+{{ L "ID" }} #{{ model.Match.Id }} - {{ L "Number of changes" }}: {{ model.Match.ChangeSerial }}

--- a/League/Templates/Email/TemplateName.cs
+++ b/League/Templates/Email/TemplateName.cs
@@ -14,6 +14,7 @@ public static class TemplateName
     public const string NotifyCurrentPrimaryEmailHtml = nameof(NotifyCurrentPrimaryEmailHtml);
     public const string NotifyCurrentPrimaryEmailTxt = nameof(NotifyCurrentPrimaryEmailTxt);
     public const string ResultEnteredTxt = nameof(ResultEnteredTxt);
+    public const string ResultRemovedTxt = nameof(ResultRemovedTxt);
     public const string AnnounceNextMatchTxt = nameof(AnnounceNextMatchTxt);
     public const string RemindMatchResultTxt = nameof(RemindMatchResultTxt);
     public const string UrgeMatchResultTxt = nameof(UrgeMatchResultTxt);

--- a/League/TextTemplatingModule/EmailTemplateDefinitionProvider.cs
+++ b/League/TextTemplatingModule/EmailTemplateDefinitionProvider.cs
@@ -18,7 +18,7 @@ public class EmailTemplateDefinitionProvider : TemplateDefinitionProvider
                     defaultCultureName: CultureInfo.DefaultThreadCurrentCulture?.Name ?? fallbackCultureName,
                     layout: TemplateName.HtmlLayout)
                 .WithVirtualFilePath(
-                    "/Email/ConfirmNewPrimaryEmailHtml.tpl", //template content path
+                    "/Email/" + nameof(TemplateName.ConfirmNewPrimaryEmailHtml) + ".tpl", //template content path
                     isInlineLocalized: true
                 )
         );
@@ -29,7 +29,7 @@ public class EmailTemplateDefinitionProvider : TemplateDefinitionProvider
                     localizationResource: typeof(EmailResource),
                     defaultCultureName: CultureInfo.DefaultThreadCurrentCulture?.Name ?? fallbackCultureName)
                 .WithVirtualFilePath(
-                    "/Email/ConfirmNewPrimaryEmailTxt.tpl", //template content path
+                    "/Email/" + nameof(TemplateName.ConfirmNewPrimaryEmailTxt) + ".tpl", //template content path
                     isInlineLocalized: true
                 )
         );
@@ -40,7 +40,7 @@ public class EmailTemplateDefinitionProvider : TemplateDefinitionProvider
                 localizationResource: typeof(EmailResource),
                 defaultCultureName: CultureInfo.DefaultThreadCurrentCulture?.Name ?? fallbackCultureName
             ).WithVirtualFilePath(
-                "/Email/ConfirmTeamApplicationTxt.tpl", //template content path
+                "/Email/" + nameof(TemplateName.ConfirmTeamApplicationTxt) + ".tpl", //template content path
                 isInlineLocalized: true
             )
         );
@@ -51,7 +51,7 @@ public class EmailTemplateDefinitionProvider : TemplateDefinitionProvider
                 localizationResource: typeof(EmailResource),
                 defaultCultureName: CultureInfo.DefaultThreadCurrentCulture?.Name ?? fallbackCultureName
             ).WithVirtualFilePath(
-                "/Email/ContactFormTxt.tpl", //template content folder
+                "/Email/" + nameof(TemplateName.ContactFormTxt) + ".tpl", //template content folder
                 isInlineLocalized: true
             )
         );
@@ -63,7 +63,7 @@ public class EmailTemplateDefinitionProvider : TemplateDefinitionProvider
                     defaultCultureName: CultureInfo.DefaultThreadCurrentCulture?.Name ?? fallbackCultureName,
                     layout: TemplateName.HtmlLayout)
                 .WithVirtualFilePath(
-                    "/Email/PasswordResetHtml.tpl", //template content path
+                    "/Email/" + nameof(TemplateName.PasswordResetHtml) + ".tpl", //template content path
                     isInlineLocalized: true
                 )
         );
@@ -74,7 +74,7 @@ public class EmailTemplateDefinitionProvider : TemplateDefinitionProvider
                     localizationResource: typeof(EmailResource),
                     defaultCultureName: CultureInfo.DefaultThreadCurrentCulture?.Name ?? fallbackCultureName)
                 .WithVirtualFilePath(
-                    "/Email/PasswordResetTxt.tpl", //template content path
+                    "/Email/" + nameof(TemplateName.PasswordResetTxt) + ".tpl", //template content path
                     isInlineLocalized: true
                 )
         );
@@ -86,7 +86,7 @@ public class EmailTemplateDefinitionProvider : TemplateDefinitionProvider
                     defaultCultureName: CultureInfo.DefaultThreadCurrentCulture?.Name ?? fallbackCultureName,
                     layout: TemplateName.HtmlLayout)
                 .WithVirtualFilePath(
-                    "/Email/PleaseConfirmEmailHtml.tpl", //template content path
+                    "/Email/" + nameof(TemplateName.PleaseConfirmEmailHtml) + ".tpl", //template content path
                     isInlineLocalized: true
                 )
         );
@@ -97,7 +97,7 @@ public class EmailTemplateDefinitionProvider : TemplateDefinitionProvider
                     localizationResource: typeof(EmailResource),
                     defaultCultureName: CultureInfo.DefaultThreadCurrentCulture?.Name ?? fallbackCultureName)
                 .WithVirtualFilePath(
-                    "/Email/PleaseConfirmEmailTxt.tpl", //template content path
+                    "/Email/" + nameof(TemplateName.PleaseConfirmEmailTxt) + ".tpl", //template content path
                     isInlineLocalized: true
                 )
         );
@@ -108,7 +108,7 @@ public class EmailTemplateDefinitionProvider : TemplateDefinitionProvider
                 localizationResource: typeof(EmailResource),
                 defaultCultureName: CultureInfo.DefaultThreadCurrentCulture?.Name ?? fallbackCultureName
             ).WithVirtualFilePath(
-                "/Email/ChangeFixtureTxt.tpl", //template content folder
+                "/Email/" + nameof(TemplateName.ChangeFixtureTxt) + ".tpl", //template content folder
                 isInlineLocalized: true
             )
         );
@@ -120,7 +120,7 @@ public class EmailTemplateDefinitionProvider : TemplateDefinitionProvider
                     defaultCultureName: CultureInfo.DefaultThreadCurrentCulture?.Name ?? fallbackCultureName,
                     layout: TemplateName.HtmlLayout)
                 .WithVirtualFilePath(
-                    "/Email/NotifyCurrentPrimaryEmailHtml.tpl", //template content path
+                    "/Email/" + nameof(TemplateName.NotifyCurrentPrimaryEmailHtml) + ".tpl", //template content path
                     isInlineLocalized: true
                 )
         );
@@ -131,7 +131,7 @@ public class EmailTemplateDefinitionProvider : TemplateDefinitionProvider
                     localizationResource: typeof(EmailResource),
                     defaultCultureName: CultureInfo.DefaultThreadCurrentCulture?.Name ?? fallbackCultureName)
                 .WithVirtualFilePath(
-                    "/Email/NotifyCurrentPrimaryEmailTxt.tpl", //template content path
+                    "/Email/" + nameof(TemplateName.NotifyCurrentPrimaryEmailTxt) + ".tpl", //template content path
                     isInlineLocalized: true
                 )
         );
@@ -142,18 +142,29 @@ public class EmailTemplateDefinitionProvider : TemplateDefinitionProvider
                 localizationResource: typeof(EmailResource),
                 defaultCultureName: CultureInfo.DefaultThreadCurrentCulture?.Name ?? fallbackCultureName
             ).WithVirtualFilePath(
-                "/Email/ResultEnteredTxt.tpl", //template content folder
+                "/Email/" + nameof(TemplateName.ResultEnteredTxt) + ".tpl", //template content folder
                 isInlineLocalized: true
             )
         );
-            
+
+        context.Add(
+            new TemplateDefinition(
+                name: TemplateName.ResultRemovedTxt,
+                localizationResource: typeof(EmailResource),
+                defaultCultureName: CultureInfo.DefaultThreadCurrentCulture?.Name ?? fallbackCultureName
+            ).WithVirtualFilePath(
+                "/Email/" + nameof(TemplateName.ResultRemovedTxt) + ".tpl", //template content folder
+                isInlineLocalized: true
+            )
+        );
+
         context.Add(
             new TemplateDefinition(
                 name: TemplateName.AnnounceNextMatchTxt,
                 localizationResource: null,
                 defaultCultureName: CultureInfo.DefaultThreadCurrentCulture?.Name ?? fallbackCultureName
             ).WithVirtualFilePath(
-                "/Email/AnnounceNextMatchTxt", //template content folder
+                "/Email/" + nameof(TemplateName.AnnounceNextMatchTxt) + ".tpl", //template content folder
                 isInlineLocalized: false
             )
         );
@@ -164,7 +175,7 @@ public class EmailTemplateDefinitionProvider : TemplateDefinitionProvider
                 localizationResource: null,
                 defaultCultureName: CultureInfo.DefaultThreadCurrentCulture?.Name ?? fallbackCultureName
             ).WithVirtualFilePath(
-                "/Email/RemindMatchResultTxt", //template content folder
+                "/Email/" + nameof(TemplateName.RemindMatchResultTxt) + ".tpl", //template content folder
                 isInlineLocalized: false
             )
         );
@@ -175,7 +186,7 @@ public class EmailTemplateDefinitionProvider : TemplateDefinitionProvider
                 localizationResource: null,
                 defaultCultureName: CultureInfo.DefaultThreadCurrentCulture?.Name ?? fallbackCultureName
             ).WithVirtualFilePath(
-                "/Email/UrgeMatchResultTxt", //template content folder
+                "/Email/" + nameof(TemplateName.UrgeMatchResultTxt) + ".tpl", //template content folder
                 isInlineLocalized: false
             )
         );
@@ -185,7 +196,7 @@ public class EmailTemplateDefinitionProvider : TemplateDefinitionProvider
                 TemplateName.HtmlLayout,
                 isLayout: true
             ).WithVirtualFilePath(
-                "/Email/HtmlLayout.tpl", //template content path
+                "/Email/" + nameof(TemplateName.HtmlLayout) + ".tpl", //template content path
                 isInlineLocalized: true
             )
         );

--- a/League/Views/Match/EnterResult.cshtml
+++ b/League/Views/Match/EnterResult.cshtml
@@ -161,7 +161,7 @@
         }
         @if (Model.IsOverruling)
         {
-            <div class="row">
+            <div class="row mb-3">
                 <label class="form-label">@Localizer["Match Points"]</label>
                 <div class="input-group">
                     <input asp-for="@Model.HomePoints" type="text" autocomplete="off" class="form-control text-start @(AddMatchPointsErr())" style="max-width:5em"/>
@@ -171,6 +171,7 @@
                     <input asp-for="@Model.GuestPoints" type="text" autocomplete="off" class="form-control text-end @(AddMatchPointsErr())" style="max-width:5em"/>
                 </div>
             </div>
+            <hr />
         }
         <div class="row">
             <div class="mb-3 col-12 col-md-8">
@@ -187,19 +188,28 @@
             </div>
         </div>
         <div class="row">
-            <div class="mb-3 col-12 mt-2">
+            <div class="mb-3 col-12 col-md-6 mt-2">
                 @{
                     if (Model.ReturnUrl != null && Url.IsLocalUrl(Model.ReturnUrl))
                     {
-                        <a href="@Model.ReturnUrl" class="btn btn-lg btn-secondary">@Localizer["Cancel"]</a>
+                        <a href="@Model.ReturnUrl" class="btn btn-lg btn-secondary me-3">@Localizer["Cancel"]</a>
                     }
                     else
                     {
-                        <a asp-controller="@nameof(League.Controllers.Match)" asp-action="@nameof(League.Controllers.Match.Fixtures)" asp-route-tenant="@tenantUrlSegment" class="btn btn-lg btn-secondary">@Localizer["Cancel"]</a>
+                        <a asp-controller="@nameof(League.Controllers.Match)" asp-action="@nameof(League.Controllers.Match.Fixtures)" asp-route-tenant="@tenantUrlSegment" class="btn btn-lg btn-secondary me-3">@Localizer["Cancel"]</a>
                     }
                 }
-                <button type="submit" value="save" class="btn btn-lg btn-primary me-5" 
+                
+                <button type="submit" value="save" class="btn btn-lg btn-primary" 
                         asp-controller="@nameof(League.Controllers.Match)" asp-action="@nameof(League.Controllers.Match.EnterResult)" asp-route-tenant="@tenantUrlSegment">@Localizer["Save"]</button>
+            </div>
+            <div class="mb-3 col-12 col-md-6 mt-md-2">
+                @if (Model is { IsOverruling: true, Match.IsComplete: true })
+                {
+                    // This creates a 'formaction' attribute on the button element
+                    <button type="submit" value="delete" class="btn btn-lg btn-warning"
+                            asp-controller="@nameof(League.Controllers.Match)" asp-action="@nameof(League.Controllers.Match.RemoveResult)" asp-route-tenant="@tenantUrlSegment"><i class="fas fa-exclamation-triangle"></i>&nbsp;@Localizer["Remove result entry"]</button>
+                }
             </div>
         </div>
     </form>

--- a/League/Views/Match/EnterResult.de.resx
+++ b/League/Views/Match/EnterResult.de.resx
@@ -129,9 +129,6 @@
   <data name="Date format" xml:space="preserve">
     <value>Datumsformat</value>
   </data>
-  <data name="DD.MM.YYYY" xml:space="preserve">
-    <value>TT.MM.JJJJ</value>
-  </data>
   <data name="Enable overruling" xml:space="preserve">
     <value>Übersteuern aktivieren</value>
   </data>
@@ -155,6 +152,9 @@
   </data>
   <data name="Remarks become part of the result submission" xml:space="preserve">
     <value>Anmerkungen sind Teil der Ergebnismeldung</value>
+  </data>
+  <data name="Remove result entry" xml:space="preserve">
+    <value>Ergebniseintrag entfernen</value>
   </data>
   <data name="Results can be changed as long as the competition is running" xml:space="preserve">
     <value>Ergebnisse können geändert werden, solange der Wettbewerb läuft</value>

--- a/League/Views/Shared/_Layout.cshtml
+++ b/League/Views/Shared/_Layout.cshtml
@@ -43,7 +43,6 @@
         </div>
     </div>
 </header>
-
     <nav id="nav-main" class="navbar navbar-expand-md navbar-dark rounded ps-2 site-sticky-top">
         @* bootstrap class "sticky-top" interferes with modal, that's why we use our identical "site-sticky-top" *@
         <div class="container-fluid ps-0">


### PR DESCRIPTION
* Add controller action `Match.RemoveResult()`
* Removing the result enforced a ranking update from scratch for the round
* Add email notification after removing a result (`Templates.Email.TemplateName.ResultRemovedTxt`)
* Update `Views.Match.EnterResult` with a button to remove the result
* Add `MatchRepository.DeleteMatchResultAsync(...)` method