### PR TITLE
Disable the deadline check, if authorized

### DIFF
--- a/TournamentManager/DAL/DatabaseSpecific/App.config
+++ b/TournamentManager/DAL/DatabaseSpecific/App.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0"?>
-<configuration>
-	<connectionStrings>
-		<!-- please adjust the connection string embedded in the element below to target the proper catalog / server using the proper user / password combination -->
-		<add name="ConnectionString.SQL Server (SqlClient)" connectionString="data source=(LocalDB)\MSSQLLocalDB;initial catalog=TestOrg;integrated security=SSPI;persist security info=False"/>
-	</connectionStrings>
-</configuration> 


### PR DESCRIPTION
Disable the deadline check when entering a match result, if the user is allowed to overrule results