### PR TITLE
Suppress false positive CA3003/S2083 warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,8 @@
         <Copyright>Copyright 2011-$(CurrentYear) axuno gGmbH</Copyright>
         <RepositoryUrl>https://github.com/axuno/Volleyball-League</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <Version>6.7.2</Version>
-        <FileVersion>6.7.2</FileVersion>
+        <Version>6.7.3</Version>
+        <FileVersion>6.7.3</FileVersion>
         <AssemblyVersion>6.0.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>

--- a/League/Caching/ReportSheetCache.cs
+++ b/League/Caching/ReportSheetCache.cs
@@ -3,11 +3,13 @@
 // Licensed under the MIT license.
 //
 
-using OxyPlot;
 using TournamentManager.DAL.TypedViewClasses;
 using TournamentManager.MultiTenancy;
 
 namespace League.Caching;
+
+#pragma warning disable S2083   // reason: False positive due to CancellationToken in GetOrCreatePdf
+#pragma warning disable CA3003  // reason: False positive due to CancellationToken in GetOrCreatePdf
 public class ReportSheetCache
 {
     private readonly ITenantContext _tenantContext;
@@ -234,3 +236,5 @@ public class ReportSheetCache
         }
     }
 }
+#pragma warning restore CA3003
+#pragma warning restore S2083

--- a/League/Controllers/Account.cs
+++ b/League/Controllers/Account.cs
@@ -305,16 +305,14 @@ public class Account : AbstractController
     {
         if (remoteError != null)
         {
-            _logger.LogInformation("{method} failed: {remoteError}.", nameof(ExternalSignInCallback), remoteError);
-            return SocialMediaSignInFailure($"Remote error: {remoteError}",
-                _localizer["Failed to sign-in with the social network account"].Value + $" ({remoteError})");
+            _logger.LogInformation("{method} failed. Remote error was supplied.", nameof(ExternalSignInCallback));
+            return SocialMediaSignInFailure(_localizer["Failed to sign-in with the social network account"].Value + $" ({remoteError})");
         }
         var info = await _signInManager.GetExternalLoginInfoAsync();
         if (info == null)
         {
             _logger.LogInformation("{method} failed to get external sign-in information", nameof(ExternalSignInCallback));
-            return SocialMediaSignInFailure("Failed to get external sign-in information",
-                _localizer["Failed to sign-in with the social network account"].Value);
+            return SocialMediaSignInFailure(_localizer["Failed to sign-in with the social network account"].Value);
         }
             
         // Sign-in user if provider represents a valid already registered user
@@ -323,7 +321,7 @@ public class Account : AbstractController
         if (await _signInManager.UserManager.FindByLoginAsync(info.LoginProvider, info.ProviderKey) == null)
         {
             ApplicationUser? existingUser = null;
-            // if the the current user is signed-in
+            // if the current user is signed in
             if (User.Identity!.IsAuthenticated)
             {
                 existingUser = await _signInManager.UserManager.FindByNameAsync(User.Identity.Name);
@@ -344,8 +342,7 @@ public class Account : AbstractController
                 if (await _signInManager.UserManager.AddLoginAsync(existingUser, info) != IdentityResult.Success)
                 {
                     _logger.LogInformation("{method} {email} is already associated with another account", nameof(ExternalSignInCallback), existingUser.Email);
-                    return SocialMediaSignInFailure($"Social network account for {existingUser.Email} is already associated with another account",
-                        _localizer.GetString("Your {0} account is already associated with another account at {1}", info.LoginProvider, _tenantContext.OrganizationContext.ShortName).Value);
+                    return SocialMediaSignInFailure(_localizer.GetString("Your {0} account is already associated with another account at {1}", info.LoginProvider, _tenantContext.OrganizationContext.ShortName).Value);
                 }
 
                 await UpdateUserFromExternalLogin(existingUser, info);
@@ -591,11 +588,8 @@ public class Account : AbstractController
         return Redirect(Url.IsLocalUrl(returnUrl) ? returnUrl : string.Empty);
     }
 
-    private IActionResult SocialMediaSignInFailure(string logErrorText, string errorMessage)
+    private IActionResult SocialMediaSignInFailure(string errorMessage)
     {
-#pragma warning disable CA2254 // Template should be a static expression
-        _logger.LogWarning(logErrorText);
-#pragma warning restore CA2254 // Template should be a static expression
         // using POST-REDIRECT-GET (PRG) design pattern might be better: https://andrewlock.net/post-redirect-get-using-tempdata-in-asp-net-core/
         ModelState.AddModelError(string.Empty, errorMessage);
         ViewData["Form"] = "SocialMedia"; // select the form for the validation summary


### PR DESCRIPTION
Reason: False positive due to `CancellationToken` which is safe 
More:
* Remove logging the error message supplied as action parameter
* Bump version to v6.7.3