### PR TITLE
Puppeteer update

### DIFF
--- a/League/Caching/ReportSheetCache.cs
+++ b/League/Caching/ReportSheetCache.cs
@@ -10,11 +10,16 @@ namespace League.Caching;
 
 #pragma warning disable S2083   // reason: False positive due to CancellationToken in GetOrCreatePdf
 #pragma warning disable CA3003  // reason: False positive due to CancellationToken in GetOrCreatePdf
+
+/// <summary>
+/// Represents a cache for report sheets.
+/// </summary>
 public class ReportSheetCache
 {
     private readonly ITenantContext _tenantContext;
     private readonly IWebHostEnvironment _webHostEnvironment;
     private readonly string _pathToChromium;
+    private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<ReportSheetCache> _logger;
 
     /// <summary>
@@ -28,24 +33,45 @@ public class ReportSheetCache
     /// </summary>
     public const string ReportSheetFilenameTemplate = "Sheet_{0}_{1}_{2}.pdf";
 
-    public ReportSheetCache(ITenantContext tenantContext, IConfiguration configuration, IWebHostEnvironment webHostEnvironment, ILogger<ReportSheetCache> logger)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReportSheetCache"/> class.
+    /// </summary>
+    /// <param name="tenantContext"></param>
+    /// <param name="configuration"></param>
+    /// <param name="webHostEnvironment"></param>
+    /// <param name="loggerFactory"></param>
+    public ReportSheetCache(ITenantContext tenantContext, IConfiguration configuration, IWebHostEnvironment webHostEnvironment, ILoggerFactory loggerFactory)
     {
         _tenantContext = tenantContext;
         _webHostEnvironment = webHostEnvironment;
         _pathToChromium = Path.Combine(webHostEnvironment.ContentRootPath, configuration["Chromium:ExecutablePath"] ?? string.Empty);
-        _logger = logger;
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory.CreateLogger<ReportSheetCache>();
     }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use Puppeteer for generating the report sheet,
+    /// instead of Chromium command line.
+    /// </summary>
+    public bool UsePuppeteer { get; set; } = false;
 
     private void EnsureCacheFolder()
     {
         var cacheFolder = Path.Combine(_webHostEnvironment.WebRootPath, ReportSheetCacheFolder);
         if (!Directory.Exists(cacheFolder))
         {
-            _logger.LogDebug("Cache folder '{CacheFolder}' created", cacheFolder);
             Directory.CreateDirectory(cacheFolder);
+            _logger.LogDebug("Cache folder '{CacheFolder}' created", cacheFolder);
         }
     }
 
+    /// <summary>
+    /// Gets or creates a PDF file for a match report sheet.
+    /// </summary>
+    /// <param name="data"></param>
+    /// <param name="html"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>A <see cref="Stream"/> of the PDF file.</returns>
     public async Task<Stream> GetOrCreatePdf(MatchReportSheetRow data, string html, CancellationToken cancellationToken)
     {
         EnsureCacheFolder();
@@ -55,9 +81,11 @@ public class ReportSheetCache
         if (!File.Exists(cacheFile) || IsOutdated(cacheFile, data.ModifiedOn))
         {
             _logger.LogDebug("Create new match report for tenant '{Tenant}', match '{MatchId}'", _tenantContext.Identifier, data.Id);
-            // cacheFile = await GetReportSheetChromium(data.Id, html, cancellationToken);
-            cacheFile = await GetReportSheetPuppeteer(data.Id, html, cancellationToken);
-            // GetReportSheetPuppeteer(...) still throws on production server
+
+            cacheFile = UsePuppeteer
+                ? await GetReportSheetPuppeteer(data.Id, html, cancellationToken)
+                : await GetReportSheetChromium(data.Id, html, cancellationToken);
+
             if (cacheFile == null) return Stream.Null;
         }
 
@@ -122,15 +150,15 @@ public class ReportSheetCache
             Headless = true,
             Browser = PuppeteerSharp.SupportedBrowser.Chromium,
             // Alternative: --use-cmd-decoder=validating 
-            Args = new[]
-                { "--no-sandbox", "--disable-gpu", "--disable-extensions", "--use-cmd-decoder=passthrough" },
+            // Args = new[]  // removed on 2024-09-23
+            //    { "--no-sandbox", "--disable-gpu", "--disable-extensions", "--use-cmd-decoder=passthrough" },
             ExecutablePath = _pathToChromium,
             Timeout = 5000
         };
         // Use Puppeteer as a wrapper for the browser, which can generate PDF from HTML
         // Start command line arguments set by Puppeteer:
         // --allow-pre-commit-input --disable-background-networking --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-breakpad --disable-client-side-phishing-detection --disable-component-extensions-with-background-pages --disable-component-update --disable-default-apps --disable-dev-shm-usage --disable-extensions --disable-features=Translate,BackForwardCache,AcceptCHFrame,MediaRouter,OptimizationHints --disable-hang-monitor --disable-ipc-flooding-protection --disable-popup-blocking --disable-prompt-on-repost --disable-renderer-backgrounding --disable-sync --enable-automation --enable-blink-features=IdleDetection --enable-features=NetworkServiceInProcess2 --export-tagged-pdf --force-color-profile=srgb --metrics-recording-only --no-first-run --password-store=basic --use-mock-keychain --headless
-        await using var browser = await PuppeteerSharp.Puppeteer.LaunchAsync(options).ConfigureAwait(false);
+        await using var browser = await PuppeteerSharp.Puppeteer.LaunchAsync(options, _loggerFactory).ConfigureAwait(false);
         await using var page = await browser.NewPageAsync().ConfigureAwait(false);
 
         await page.SetContentAsync(html); // Bootstrap 5 is loaded from CDN
@@ -159,11 +187,19 @@ public class ReportSheetCache
    |url: https://volleyball-liga.de/augsburg/match/reportsheet/3188|action: ReportSheet
          */
         var fullPath = GetPathToCacheFile(matchId);
+        try
+        {
+            // page.PdfDataAsync times out after 180,000ms (3 minutes)
+            var bytes = await page.PdfDataAsync(new PuppeteerSharp.PdfOptions
+                { Scale = 1.0M, Format = PuppeteerSharp.Media.PaperFormat.A4 }).ConfigureAwait(false);
 
-        var bytes = await page.PdfDataAsync(new PuppeteerSharp.PdfOptions
-            { Scale = 1.0M, Format = PuppeteerSharp.Media.PaperFormat.A4 }).ConfigureAwait(false);
-
-        await File.WriteAllBytesAsync(fullPath, bytes, cancellationToken);
+            await File.WriteAllBytesAsync(fullPath, bytes, cancellationToken);
+        }
+        catch(Exception ex)
+        {
+            _logger.LogError(ex, "Error creating PDF file with Puppeteer for match ID '{MatchId}'", matchId);
+            await File.WriteAllBytesAsync(fullPath, Array.Empty<byte>(), cancellationToken);
+        }
 
         return fullPath;
     }

--- a/League/Caching/ReportSheetCache.cs
+++ b/League/Caching/ReportSheetCache.cs
@@ -55,8 +55,9 @@ public class ReportSheetCache
         if (!File.Exists(cacheFile) || IsOutdated(cacheFile, data.ModifiedOn))
         {
             _logger.LogDebug("Create new match report for tenant '{Tenant}', match '{MatchId}'", _tenantContext.Identifier, data.Id);
-            cacheFile = await GetReportSheetChromium(data.Id, html, cancellationToken);
-            // GetReportSheetPuppeteer() still throws on production server
+            // cacheFile = await GetReportSheetChromium(data.Id, html, cancellationToken);
+            cacheFile = await GetReportSheetPuppeteer(data.Id, html, cancellationToken);
+            // GetReportSheetPuppeteer(...) still throws on production server
             if (cacheFile == null) return Stream.Null;
         }
 
@@ -119,7 +120,7 @@ public class ReportSheetCache
         var options = new PuppeteerSharp.LaunchOptions
         {
             Headless = true,
-            Product = PuppeteerSharp.Product.Chrome,
+            Browser = PuppeteerSharp.SupportedBrowser.Chromium,
             // Alternative: --use-cmd-decoder=validating 
             Args = new[]
                 { "--no-sandbox", "--disable-gpu", "--disable-extensions", "--use-cmd-decoder=passthrough" },

--- a/League/Controllers/Match.cs
+++ b/League/Controllers/Match.cs
@@ -714,6 +714,7 @@ public class Match : AbstractController
     public async Task<IActionResult> ReportSheet(long id, [FromServices] ReportSheetCache cache, CancellationToken cancellationToken)
     {
         MatchReportSheetRow? model = null;
+        cache.UsePuppeteer = false;
             
         try
         {
@@ -730,7 +731,6 @@ public class Match : AbstractController
             var html = await _razorViewToStringRenderer.RenderViewToStringAsync(
                 $"~/Views/{nameof(Match)}/{ViewNames.Match.ReportSheet}.cshtml", model);
 
-            //var cache = new ReportSheetCache(_tenantContext, _configuration, _webHostEnvironment);
             var stream = await cache.GetOrCreatePdf(model, html, cancellationToken);
             _logger.LogInformation("PDF file returned for tenant '{Tenant}' and match id '{MatchId}'", _tenantContext.Identifier, id);
             return new FileStreamResult(stream, "application/pdf");

--- a/League/League.csproj
+++ b/League/League.csproj
@@ -85,7 +85,7 @@ Localizations for English and German are included. The library is in operation o
             <PackEmbeddedResource>true</PackEmbeddedResource>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="PuppeteerSharp" Version="9.1.0" />
+        <PackageReference Include="PuppeteerSharp" Version="20.0.2" />
         <PackageReference Include="StackifyMiddleware" Version="3.3.3.4767" />
         <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />


### PR DESCRIPTION
* Update puppeteer to 20.0.2 to generate match reports as PDF
* ReportSheetCache can switch between Puppeteer and Chromium command line to generate PDFs
* Create ReportSheetCache instance with ILoggerFactory
* Note: Puppeteer can currently create PDF files only with Chrome
