### PR TITLE
Update NuGet package dependencies across projects

### DIFF
--- a/Axuno.BackgroundTask.Test/Axuno.BackgroundTask.Tests.csproj
+++ b/Axuno.BackgroundTask.Test/Axuno.BackgroundTask.Tests.csproj
@@ -5,17 +5,17 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="nunit" Version="4.1.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="nunit" Version="4.2.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Axuno.BackgroundTask\Axuno.BackgroundTask.csproj" />

--- a/Axuno.BackgroundTask/Axuno.BackgroundTask.csproj
+++ b/Axuno.BackgroundTask/Axuno.BackgroundTask.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Cronos" Version="0.8.4" />
-    <PackageReference Include="NuGetizer" Version="1.2.2">
+    <PackageReference Include="NuGetizer" Version="1.2.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Axuno.Tools.Tests/Axuno.Tools.Tests.csproj
+++ b/Axuno.Tools.Tests/Axuno.Tools.Tests.csproj
@@ -20,17 +20,17 @@
     <EmbeddedResource Include="FileSystem\Data\my-json-file.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="nunit" Version="4.1.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="nunit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Axuno.Tools\Axuno.Tools.csproj" />

--- a/Axuno.Tools/Axuno.Tools.csproj
+++ b/Axuno.Tools/Axuno.Tools.csproj
@@ -9,8 +9,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NodaTime" Version="3.1.11" />
-    <PackageReference Include="NuGetizer" Version="1.2.2">
+    <PackageReference Include="NodaTime" Version="3.1.12" />
+    <PackageReference Include="NuGetizer" Version="1.2.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Axuno.Web/Axuno.Web.csproj
+++ b/Axuno.Web/Axuno.Web.csproj
@@ -7,8 +7,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.6.2" />
-    <PackageReference Include="NuGetizer" Version="1.2.2">
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.1.0" />
+    <PackageReference Include="NuGetizer" Version="1.2.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/League.Tests/League.Tests.csproj
+++ b/League.Tests/League.Tests.csproj
@@ -5,24 +5,24 @@
     <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="4.1.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
+    <PackageReference Include="Azure.Identity" Version="1.12.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.6" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.8" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="ObjectsComparer" Version="1.4.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.2" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\League.Demo\League.Demo.csproj" />

--- a/League/League.csproj
+++ b/League/League.csproj
@@ -64,23 +64,23 @@ Localizations for English and German are included. The library is in operation o
         <Using Include="Microsoft.Extensions.Options" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Axuno.TextTemplating" Version="2.0.1" />
+        <PackageReference Include="Axuno.TextTemplating" Version="2.1.0" />
         <PackageReference Include="JSNLog" Version="3.0.3" />
-        <PackageReference Include="MailMergeLib" Version="5.12.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.6" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.6" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.6" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.6" />
+        <PackageReference Include="MailMergeLib" Version="5.12.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.8" />
         <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.2" />
+        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.5" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="NLog" Version="5.3.2" />
-        <PackageReference Include="NLog.Web.AspNetCore" Version="5.3.11" />
-        <PackageReference Include="NuGetizer" Version="1.2.2">
+        <PackageReference Include="NLog" Version="5.3.4" />
+        <PackageReference Include="NLog.Web.AspNetCore" Version="5.3.14" />
+        <PackageReference Include="NuGetizer" Version="1.2.3">
             <PrivateAssets>all</PrivateAssets>
             <PackEmbeddedResource>true</PackEmbeddedResource>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/TournamentManager/DAL/DatabaseGeneric/TournamentManager.DAL.DbGeneric.csproj
+++ b/TournamentManager/DAL/DatabaseGeneric/TournamentManager.DAL.DbGeneric.csproj
@@ -8,7 +8,7 @@
     <NoWarn>CA5362;CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="1.2.2">
+    <PackageReference Include="NuGetizer" Version="1.2.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TournamentManager/DAL/DatabaseSpecific/TournamentManager.DAL.DBSpecific.csproj
+++ b/TournamentManager/DAL/DatabaseSpecific/TournamentManager.DAL.DBSpecific.csproj
@@ -7,7 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="1.2.2">
+    <PackageReference Include="NuGetizer" Version="1.2.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TournamentManager/TournamentManager.Tests/TournamentManager.Tests.csproj
+++ b/TournamentManager/TournamentManager.Tests/TournamentManager.Tests.csproj
@@ -6,15 +6,15 @@
     <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="4.1.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DAL\DatabaseGeneric\TournamentManager.DAL.DbGeneric.csproj" />

--- a/TournamentManager/TournamentManager/TournamentManager.csproj
+++ b/TournamentManager/TournamentManager/TournamentManager.csproj
@@ -17,21 +17,21 @@ Volleyball League is an open source sports platform that brings everything neces
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EPPlus" Version="7.2.0" />
-    <PackageReference Include="NLog" Version="5.3.2" />
-    <PackageReference Include="NuGetizer" Version="1.2.2">
+    <PackageReference Include="EPPlus" Version="7.3.2" />
+    <PackageReference Include="NLog" Version="5.3.4" />
+    <PackageReference Include="NuGetizer" Version="1.2.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OxyPlot.Core" Version="2.1.2" />
-    <PackageReference Include="OxyPlot.SkiaSharp" Version="2.1.2" />
+    <PackageReference Include="OxyPlot.Core" Version="2.2.0" />
+    <PackageReference Include="OxyPlot.SkiaSharp" Version="2.2.0" />
     <PackageReference Include="PuppeteerSharp" Version="20.0.2" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="Ical.Net" Version="4.2.0" />
-    <PackageReference Include="libphonenumber-csharp" Version="8.13.39" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.11" />
+    <PackageReference Include="libphonenumber-csharp" Version="8.13.46" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.14" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
-    <PackageReference Include="YAXLib" Version="4.2.2" />
+    <PackageReference Include="YAXLib" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Axuno.Tools\Axuno.Tools.csproj" />


### PR DESCRIPTION
Updated various NuGet package dependencies to their latest versions for improved functionality, security, and compatibility. Key updates include:

- FluentAssertions: 6.12.0 to 6.12.1
- NUnit: 4.1.0 to 4.2.2
- NUnit.Analyzers: 4.2.0 to 4.3.0
- NUnit3TestAdapter: 4.5.0 to 4.6.0
- Microsoft.NET.Test.Sdk: 17.10.0 to 17.11.1
- NuGetizer: 1.2.2 to 1.2.3
- NodaTime: 3.1.11 to 3.1.12
- Microsoft.IdentityModel.Tokens: 7.6.2 to 8.1.0
- Azure.Identity: 1.12.0 to 1.12.1
- Microsoft.AspNetCore.Mvc.Testing: 8.0.6 to 8.0.8
- Microsoft.Data.SqlClient: 5.2.1 to 5.2.2
- Moq: 4.20.70 to 4.20.72
- System.IdentityModel.Tokens.Jwt: 7.6.2 to 8.1.0
- Axuno.TextTemplating: 2.0.1 to 2.1.0
- MailMergeLib: 5.12.0 to 5.12.3
- Microsoft.AspNetCore.Authentication.*: 8.0.6 to 8.0.8
- Microsoft.VisualStudio.Web.CodeGeneration.Design: 8.0.2 to 8.0.5
- NLog: 5.3.2 to 5.3.4
- NLog.Web.AspNetCore: 5.3.11 to 5.3.14
- EPPlus: 7.2.0 to 7.3.2
- OxyPlot.Core: 2.1.2 to 2.2.0
- OxyPlot.SkiaSharp: 2.1.2 to 2.2.0
- libphonenumber-csharp: 8.13.39 to 8.13.46
- NLog.Extensions.Logging: 5.3.11 to 5.3.14
- YAXLib: 4.2.2 to 4.3.0