### PR TITLE
Refactor TimeZoneConverter to remove NodaTime dependency

### DIFF
--- a/Axuno.Tools.Tests/DateAndTime/TimeZoneConverterTests.cs
+++ b/Axuno.Tools.Tests/DateAndTime/TimeZoneConverterTests.cs
@@ -134,7 +134,7 @@ public class TimeZoneConverterTests
         var expectedDateTime = new DateTime(2022, 1, 1, 7, 0, 0, DateTimeKind.Utc);
 
         // Act
-        var convertedDateTime = GetTimeZoneConverter("en-US").ToUtc(localDateTime, "Europe/Berlin");
+        var convertedDateTime = Axuno.Tools.DateAndTime.TimeZoneConverter.ToUtc(localDateTime, "Europe/Berlin");
 
         // Assert
         Assert.That(convertedDateTime, Is.EqualTo(expectedDateTime));
@@ -186,7 +186,7 @@ public class TimeZoneConverterTests
         DateTime? dateTimeOfAnyKind = null;
 
         // Act
-        var convertedDateTime = GetTimeZoneConverter("en-US").ToUtc(dateTimeOfAnyKind, "Europe/Berlin");
+        var convertedDateTime = Axuno.Tools.DateAndTime.TimeZoneConverter.ToUtc(dateTimeOfAnyKind, "Europe/Berlin");
 
         // Assert
         Assert.That(convertedDateTime, Is.Null);

--- a/Axuno.Tools/Axuno.Tools.csproj
+++ b/Axuno.Tools/Axuno.Tools.csproj
@@ -9,7 +9,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NodaTime" Version="3.1.12" />
     <PackageReference Include="NuGetizer" Version="1.2.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Axuno.Tools/DateAndTime/IZonedTimeInfo.cs
+++ b/Axuno.Tools/DateAndTime/IZonedTimeInfo.cs
@@ -8,14 +8,19 @@ namespace Axuno.Tools.DateAndTime;
 public interface IZonedTimeInfo
 {
     /// <summary>
-    /// Gets the <see cref="CultureInfo"/> used for localization.
+    /// Gets the <see cref="System.Globalization.CultureInfo"/> used for localization.
     /// </summary>
     CultureInfo CultureInfo { get; }
 
     /// <summary>
-    /// Gets the IANA timezone ID related to the <see cref="DateTimeOffset"/>.
+    /// Gets the IANA timezone ID related to the <see cref="System.DateTimeOffset"/>.
     /// </summary>
     string TimeZoneId { get; }
+
+    /// <summary>
+    /// Gets the <see cref="System.DateTimeOffset"/> which is set based on the timezone offset to UTC.
+    /// </summary>
+    DateTimeOffset DateTimeOffset { get; }
 
     /// <summary>
     /// Gets the generic name for the time zone.
@@ -33,17 +38,17 @@ public interface IZonedTimeInfo
     string DisplayName { get; }
 
     /// <summary>
-    /// Gets the name of the timezone related to the <see cref="DateTimeOffset"/>.
+    /// Gets the name of the timezone related to the <see cref="System.DateTimeOffset"/>.
     /// </summary>
     string Name { get; }
 
     /// <summary>
-    /// Gets the timezone abbreviation related to the <see cref="DateTimeOffset"/>.
+    /// Gets the timezone abbreviation related to the <see cref="System.DateTimeOffset"/>.
     /// </summary>
     string Abbreviation { get; }
 
     /// <summary>
-    /// Gets whether the timezone related to the <see cref="DateTimeOffset"/> is daylight saving time.
+    /// Gets whether the timezone related to the <see cref="System.DateTimeOffset"/> is daylight saving time.
     /// </summary>
     bool IsDaylightSavingTime { get; }
 

--- a/Axuno.Tools/DateAndTime/TimeZoneConverter.cs
+++ b/Axuno.Tools/DateAndTime/TimeZoneConverter.cs
@@ -1,49 +1,30 @@
 ﻿using System.Globalization;
-using NodaTime;
-using NodaTime.TimeZones;
-using TzConverter = TimeZoneConverter;
-namespace Axuno.Tools.DateAndTime;
+using TimeZoneNames;
 
+namespace Axuno.Tools.DateAndTime;
 /// <summary>
-/// Converts from <see cref="DateTime"/> or <see cref="DateTimeOffset"/> and zone specific <see cref="ZonedTime"/>.
+/// Converts between <see cref="DateTime"/> or <see cref="DateTimeOffset"/> and zone specific <see cref="ZonedTime"/>.
 /// </summary>
-/// <remarks>
-/// There is a NuGet package "TimeZoneConverter", version=6.1.0+ which might be able to replace this class.
-/// Credits to Joe Audette's blog who introduced a similar solution. Unfortunately Joe passed away in 2020.
-/// </remarks>
 public class TimeZoneConverter
 {
-    private readonly IDateTimeZoneProvider _dateTimeZoneProvider;
-    private readonly string _timeZoneId;
-    private readonly CultureInfo? _cultureInfo;
-    private readonly ZoneLocalMappingResolver? _resolver;
+    // IANA timezone ID
+    private readonly string _ianaTimeZoneId;
+    private readonly CultureInfo _cultureInfo;
 
     /// <summary>
     /// CTOR.
     /// </summary>
-    /// <param name="dateTimeZoneProvider"></param>
-    /// <param name="timeZoneInfo">The Windows <see cref="TimeZoneInfo"/> to use for converting.</param>
-    /// <param name="cultureInfo">The <see cref="CultureInfo"/> to use for converting.</param>
-    /// <param name="resolver">The <see cref="ZoneLocalMappingResolver"/> to use for converting.</param>
-    public TimeZoneConverter(IDateTimeZoneProvider dateTimeZoneProvider, TimeZoneInfo timeZoneInfo,
-        CultureInfo? cultureInfo = null, ZoneLocalMappingResolver? resolver = null) : this(dateTimeZoneProvider,
-        TzConverter.TZConvert.WindowsToIana(timeZoneInfo.Id), cultureInfo, resolver)
-    {}
-
-    /// <summary>
-    /// CTOR.
-    /// </summary>
-    /// <param name="dateTimeZoneProvider"></param>
-    /// <param name="ianaTimeZoneId">The IANA timezone ID to use for converting.</param>
-    /// <param name="cultureInfo">The <see cref="CultureInfo"/> to use for converting.</param>
-    /// <param name="resolver">The <see cref="ZoneLocalMappingResolver"/> to use for converting.</param>
-    public TimeZoneConverter(IDateTimeZoneProvider dateTimeZoneProvider, string ianaTimeZoneId,
-        CultureInfo? cultureInfo = null, ZoneLocalMappingResolver? resolver = null)
+    /// <param name="ianaTimeZoneId">
+    /// The IANA timezone ID to use for converting.
+    /// We initialize with IANA because of compatibility with the NodaTime TimeZoneConverter we had before.
+    /// </param>
+    /// <param name="cultureInfo">The <see cref="CultureInfo"/> to use for converting. Default is <see cref="CultureInfo.CurrentUICulture"/>.</param>
+    /// <exception cref="TimeZoneNotFoundException"></exception>
+    public TimeZoneConverter(string ianaTimeZoneId, CultureInfo? cultureInfo = null)
     {
-        _dateTimeZoneProvider = dateTimeZoneProvider;
-        _timeZoneId = ianaTimeZoneId;
-        _cultureInfo = cultureInfo;
-        _resolver = resolver;
+        _ianaTimeZoneId = ianaTimeZoneId;
+        _ = TimeZoneInfo.FindSystemTimeZoneById(ianaTimeZoneId);
+        _cultureInfo = cultureInfo ?? CultureInfo.CurrentUICulture;
     }
 
     /// <summary>
@@ -53,9 +34,9 @@ public class TimeZoneConverter
     /// <param name="dateTimeOfAnyKind"></param>
     /// <param name="cultureInfo">The <see cref="CultureInfo"/> to use for time zone localization. If <see langword="null"/>, the default culture will be used.</param>
     /// <returns>Returns the converted <see cref="DateTime"/> as a <see cref="ZonedTime"/> instance or null, if the <paramref name="dateTimeOfAnyKind"/> parameter is null.</returns>
-    public ZonedTime? ToZonedTime(DateTime? dateTimeOfAnyKind, CultureInfo? cultureInfo = null)
+    public IZonedTimeInfo? ToZonedTime(DateTime? dateTimeOfAnyKind, CultureInfo? cultureInfo = null)
     {
-        return ToZonedTime(dateTimeOfAnyKind, _timeZoneId, cultureInfo ?? _cultureInfo, _dateTimeZoneProvider);
+        return ToZonedTime(dateTimeOfAnyKind, _ianaTimeZoneId, cultureInfo ?? _cultureInfo);
     }
 
     /// <summary>
@@ -65,9 +46,9 @@ public class TimeZoneConverter
     /// <param name="dateTimeOfAnyKind"></param>
     /// <param name="cultureInfo">The <see cref="CultureInfo"/> to use for time zone localization. If <see langword="null"/>, the default culture will be used.</param>
     /// <returns>Returns the converted <see cref="DateTime"/> as a <see cref="ZonedTime"/> instance.</returns>
-    public ZonedTime? ToZonedTime(DateTime dateTimeOfAnyKind, CultureInfo? cultureInfo = null)
+    public IZonedTimeInfo? ToZonedTime(DateTime dateTimeOfAnyKind, CultureInfo? cultureInfo = null)
     {
-        return ToZonedTime(dateTimeOfAnyKind, _timeZoneId, cultureInfo ?? _cultureInfo, _dateTimeZoneProvider);
+        return ToZonedTime(dateTimeOfAnyKind, _ianaTimeZoneId, cultureInfo ?? _cultureInfo);
     }
 
     /// <summary>
@@ -77,7 +58,7 @@ public class TimeZoneConverter
     /// <returns>Returns the converted <see cref="DateTime"/> with <see cref="DateTimeKind.Utc"/> or null, if the <paramref name="zoneDateTime"/> parameter is null.</returns>
     public DateTime? ToUtc(DateTime? zoneDateTime)
     {
-        return ToUtc(zoneDateTime, _timeZoneId, _dateTimeZoneProvider, _resolver);
+        return ToUtc(zoneDateTime, _ianaTimeZoneId);
     }
 
     /// <summary>
@@ -87,19 +68,23 @@ public class TimeZoneConverter
     /// <returns>Returns the converted <see cref="DateTime"/> with <see cref="DateTimeKind.Utc"/>.</returns>
     public DateTime ToUtc(DateTime zoneDateTime)
     {
-        return ToUtc(zoneDateTime, _timeZoneId, _dateTimeZoneProvider, _resolver);
+        return ToUtc(zoneDateTime, _ianaTimeZoneId);
     }
 
-    /// <summary>
-    /// Converts the <see cref="DateTime"/> of any <see cref="DateTimeKind"/> to a <see cref="DateTime"/> of <see cref="DateTimeKind.Utc"/>.
-    /// </summary>
-    /// <param name="zoneDateTime">A <see cref="DateTime"/> in the timezone specified with parameter <paramref name="timeZoneId"/>.</param>
-    /// <param name="timeZoneId">The ID of the IANA timezone database, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.</param>
-    /// <returns>Returns the converted <see cref="DateTime"/> with <see cref="DateTimeKind.Utc"/> or null, if the <paramref name="zoneDateTime"/> parameter is <see langword="null"/>.</returns>
-    /// <exception cref="DateTimeZoneNotFoundException">If <paramref name="timeZoneId"/> is unknown.</exception>
     public DateTime? ToUtc(DateTime? zoneDateTime, string timeZoneId)
     {
-        return ToUtc(zoneDateTime, timeZoneId, _dateTimeZoneProvider, _resolver);
+        if (!zoneDateTime.HasValue) return null;
+
+        // Convert IANA time zone to Windows time zone ID
+        var windowsTimeZoneId = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+
+        // Convert the local time to UTC
+        // We have to change the DateTimeKind to Unspecified, because the TimeZoneInfo.ConvertTimeToUtc method does not work with Local time
+        // This makes the method compatible with the NodaTime TimeZoneConverter we had before.
+        zoneDateTime = DateTime.SpecifyKind(zoneDateTime.Value, DateTimeKind.Unspecified);
+        var utcDateTime = TimeZoneInfo.ConvertTimeToUtc(zoneDateTime.Value, windowsTimeZoneId);
+
+        return utcDateTime;
     }
 
     /// <summary>
@@ -108,10 +93,10 @@ public class TimeZoneConverter
     /// <param name="zoneDateTime">A <see cref="DateTime"/> in the timezone specified with parameter <paramref name="timeZoneId"/>.</param>
     /// <param name="timeZoneId">The ID of the IANA timezone database, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.</param>
     /// <returns>Returns the converted <see cref="DateTime"/> with <see cref="DateTimeKind.Utc"/>.</returns>
-    /// <exception cref="DateTimeZoneNotFoundException">If <paramref name="timeZoneId"/> is unknown.</exception>
+    /// <exception cref="TimeZoneNotFoundException">If <paramref name="timeZoneId"/> is unknown.</exception>
     public DateTime ToUtc(DateTime zoneDateTime, string timeZoneId)
     {
-        return ToUtc(zoneDateTime, timeZoneId, _dateTimeZoneProvider, _resolver);
+        return (DateTime) ToUtc((DateTime?) zoneDateTime, timeZoneId)!;
     }
 
     /// <summary>
@@ -121,25 +106,20 @@ public class TimeZoneConverter
     /// <param name="dateTimeOfAnyKind"></param>
     /// <param name="timeZoneId"></param>
     /// <param name="cultureInfo">The see <see cref="CultureInfo"/> to use for localizing timezone strings. Default is <see cref="CultureInfo.CurrentUICulture"/>.</param>
-    /// <param name="timeZoneProvider">The <see cref="IDateTimeZoneProvider"/> to use. For performance use a <see cref="DateTimeZoneCache"/>.
-    /// <example>
-    /// IDateTimeZoneProvider dtzp = new DateTimeZoneCache(TzdbDateTimeZoneSource.Default)
-    /// </example>
-    /// </param>
     /// <returns>Returns the converted <see cref="DateTime"/> as a <see cref="ZonedTime"/> instance or null, if the <paramref name="dateTimeOfAnyKind"/> parameter is null.</returns>
-    /// <exception cref="DateTimeZoneNotFoundException">If <paramref name="timeZoneId"/> is unknown.</exception>
-    public static ZonedTime? ToZonedTime(DateTime? dateTimeOfAnyKind, string timeZoneId,
-        CultureInfo? cultureInfo = null, IDateTimeZoneProvider? timeZoneProvider = null)
+    /// <exception cref="TimeZoneNotFoundException">If <paramref name="timeZoneId"/> is unknown.</exception>
+    public static IZonedTimeInfo? ToZonedTime(DateTime? dateTimeOfAnyKind, string timeZoneId, CultureInfo? cultureInfo = null)
     {
         if (!dateTimeOfAnyKind.HasValue) return null;
 
-        var utcDateTime = dateTimeOfAnyKind.Value.Kind switch {
+        var utcDateTime = dateTimeOfAnyKind.Value.Kind switch
+        {
             DateTimeKind.Utc => dateTimeOfAnyKind.Value,
-            DateTimeKind.Local => dateTimeOfAnyKind.Value.ToUniversalTime(),
+            DateTimeKind.Local => TimeZoneInfo.ConvertTimeToUtc(dateTimeOfAnyKind.Value),
             _ => DateTime.SpecifyKind(dateTimeOfAnyKind.Value, DateTimeKind.Utc)
         };
 
-        return ToZonedTime(new DateTimeOffset(utcDateTime), timeZoneId, cultureInfo, timeZoneProvider);
+        return ToZonedTime(new DateTimeOffset(utcDateTime), timeZoneId, cultureInfo);
     }
 
     /// <summary>
@@ -149,17 +129,11 @@ public class TimeZoneConverter
     /// <param name="dateTimeOfAnyKind"></param>
     /// <param name="timeZoneId"></param>
     /// <param name="cultureInfo">The see <see cref="CultureInfo"/> to use for localizing timezone strings. Default is <see cref="CultureInfo.CurrentUICulture"/>.</param>
-    /// <param name="timeZoneProvider">The <see cref="IDateTimeZoneProvider"/> to use. For performance use a <see cref="DateTimeZoneCache"/>.
-    /// <example>
-    /// IDateTimeZoneProvider dtzp = new DateTimeZoneCache(TzdbDateTimeZoneSource.Default)
-    /// </example>
-    /// </param>
     /// <returns>Returns the converted <see cref="DateTime"/> as a <see cref="ZonedTime"/> instance.</returns>
-    /// <exception cref="DateTimeZoneNotFoundException">If <paramref name="timeZoneId"/> is unknown.</exception>
-    public static ZonedTime? ToZonedTime(DateTime dateTimeOfAnyKind, string timeZoneId,
-        CultureInfo? cultureInfo = null, IDateTimeZoneProvider? timeZoneProvider = null)
+    /// <exception cref="TimeZoneNotFoundException">If <paramref name="timeZoneId"/> is unknown.</exception>
+    public static IZonedTimeInfo? ToZonedTime(DateTime dateTimeOfAnyKind, string timeZoneId, CultureInfo? cultureInfo = null)
     {
-        return ToZonedTime((DateTime?) dateTimeOfAnyKind, timeZoneId, cultureInfo, timeZoneProvider);
+        return ToZonedTime((DateTime?) dateTimeOfAnyKind, timeZoneId, cultureInfo);
     }
 
     /// <summary>
@@ -168,44 +142,34 @@ public class TimeZoneConverter
     /// <param name="dateTimeOffset"></param>
     /// <param name="timeZoneId">The ID of the IANA timezone database, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.</param>
     /// <param name="cultureInfo">The see <see cref="CultureInfo"/> to use for localizing timezone strings. Default is <see cref="CultureInfo.CurrentUICulture"/>.</param>
-    /// <param name="timeZoneProvider">The <see cref="IDateTimeZoneProvider"/> to use. For performance use a <see cref="DateTimeZoneCache"/>.
-    /// <example>
-    /// IDateTimeZoneProvider dtzp = new DateTimeZoneCache(TzdbDateTimeZoneSource.Default)
-    /// </example>
-    /// </param>
     /// <returns>Returns the converted <see cref="Nullable{DateTimeOffset}"/> as a <see cref="ZonedTime"/> instance  or null, if the <paramref name="dateTimeOffset"/> parameter is null.</returns>
-    /// <exception cref="DateTimeZoneNotFoundException">If IANA <paramref name="timeZoneId"/> is unknown.</exception>
-    public static ZonedTime? ToZonedTime(DateTimeOffset? dateTimeOffset, string timeZoneId,
-        CultureInfo? cultureInfo = null, IDateTimeZoneProvider? timeZoneProvider = null)
+    /// <exception cref="TimeZoneNotFoundException">If IANA <paramref name="timeZoneId"/> is unknown.</exception>
+    public static IZonedTimeInfo? ToZonedTime(DateTimeOffset? dateTimeOffset, string timeZoneId, CultureInfo? cultureInfo = null)
     {
         if (!dateTimeOffset.HasValue) return null;
 
         var zonedDateTime = new ZonedTime();
 
-        timeZoneProvider ??= DateTimeZoneProviders.Tzdb;
         cultureInfo ??= CultureInfo.CurrentUICulture;
 
-        // throws if timeZoneId is unknown
-        var timeZone = timeZoneProvider[timeZoneId];
+        // Convert IANA time zone to Windows time zone ID
+        var windowsTimeZoneId = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
 
-        var instantInZone = Instant.FromDateTimeUtc(dateTimeOffset.Value.UtcDateTime).InZone(timeZone);
+        // Convert UTC to the specified time zone
+        var localDateTime = TimeZoneInfo.ConvertTime(dateTimeOffset.Value.UtcDateTime, windowsTimeZoneId);
+
         zonedDateTime.CultureInfo = cultureInfo;
-        zonedDateTime.DateTimeOffset = instantInZone.ToDateTimeOffset();
-        zonedDateTime.IsDaylightSavingTime = instantInZone.IsDaylightSavingTime();
-
-        var timeZoneInfo = TzConverter.TZConvert.GetTimeZoneInfo(timeZoneId);
-        zonedDateTime.DisplayName = timeZoneInfo.DisplayName;
-        zonedDateTime.BaseUtcOffset = timeZoneInfo.BaseUtcOffset;
+        zonedDateTime.DateTimeOffset = new DateTimeOffset(localDateTime, windowsTimeZoneId.GetUtcOffset(localDateTime));
+        zonedDateTime.IsDaylightSavingTime = windowsTimeZoneId.IsDaylightSavingTime(localDateTime);
+        zonedDateTime.DisplayName = windowsTimeZoneId.DisplayName;
+        zonedDateTime.BaseUtcOffset = windowsTimeZoneId.BaseUtcOffset;
         zonedDateTime.TimeZoneId = timeZoneId;
 
-        var tzNames =
-            TimeZoneNames.TZNames.GetNamesForTimeZone(timeZone.Id, cultureInfo.TwoLetterISOLanguageName);
+        var tzNames = TZNames.GetNamesForTimeZone(timeZoneId, cultureInfo.TwoLetterISOLanguageName);
         zonedDateTime.GenericName = tzNames.Generic ?? string.Empty;
         zonedDateTime.Name = (zonedDateTime.IsDaylightSavingTime ? tzNames.Daylight : tzNames.Standard) ?? string.Empty;
 
-        var tzAbbr =
-            TimeZoneNames.TZNames.GetAbbreviationsForTimeZone(timeZone.Id,
-                cultureInfo.TwoLetterISOLanguageName);
+        var tzAbbr = TZNames.GetAbbreviationsForTimeZone(timeZoneId, cultureInfo.TwoLetterISOLanguageName);
         zonedDateTime.GenericAbbreviation = tzAbbr.Generic ?? string.Empty;
         zonedDateTime.Abbreviation = (zonedDateTime.IsDaylightSavingTime ? tzAbbr.Daylight : tzAbbr.Standard) ?? string.Empty;
 
@@ -218,59 +182,13 @@ public class TimeZoneConverter
     /// <param name="dateTimeOffset"></param>
     /// <param name="timeZoneId">The ID of the IANA timezone database, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.</param>
     /// <param name="cultureInfo">The see <see cref="CultureInfo"/> to use for localizing timezone strings. Default is <see cref="CultureInfo.CurrentUICulture"/>.</param>
-    /// <param name="timeZoneProvider">The <see cref="IDateTimeZoneProvider"/> to use. For performance use a <see cref="DateTimeZoneCache"/>.
-    /// <example>
-    /// IDateTimeZoneProvider dtzp = new DateTimeZoneCache(TzdbDateTimeZoneSource.Default)
-    /// </example>
-    /// </param>
     /// <returns>Returns the converted <see cref="Nullable{DateTimeOffset}"/> as a <see cref="ZonedTime"/> instance.</returns>
-    /// <exception cref="DateTimeZoneNotFoundException">If IANA <paramref name="timeZoneId"/> is unknown.</exception>
-    public static ZonedTime? ToZonedTime(DateTimeOffset dateTimeOffset, string timeZoneId,
-        CultureInfo? cultureInfo = null, IDateTimeZoneProvider? timeZoneProvider = null)
+    /// <exception cref="TimeZoneNotFoundException">If IANA <paramref name="timeZoneId"/> is unknown.</exception>
+    public static IZonedTimeInfo? ToZonedTime(DateTimeOffset dateTimeOffset, string timeZoneId, CultureInfo? cultureInfo = null)
     {
-        return ToZonedTime((DateTimeOffset?) dateTimeOffset, timeZoneId, cultureInfo, timeZoneProvider);
+        return ToZonedTime((DateTimeOffset?) dateTimeOffset, timeZoneId, cultureInfo);
     }
 
-    /// <summary>
-    /// Converts the <see cref="DateTime"/> of any <see cref="DateTimeKind"/> to a <see cref="DateTime"/> of <see cref="DateTimeKind.Utc"/>.
-    /// </summary>
-    /// <param name="zoneDateTime"></param>
-    /// <param name="timeZoneId">The ID of the IANA timezone database, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.</param>
-    /// <param name="timeZoneProvider"></param>
-    /// <param name="resolver">The <see cref="ZoneLocalMappingResolver"/> to use. Default is <see cref="Resolvers.LenientResolver"/>´, which never throws an exception due to ambiguity or skipped time.</param>
-    /// <returns>Returns the converted <see cref="DateTime"/> with <see cref="DateTimeKind.Utc"/> or null, if the <paramref name="zoneDateTime"/> parameter is null.</returns>
-    /// <exception cref="DateTimeZoneNotFoundException">If <paramref name="timeZoneId"/> is unknown.</exception>
-    public static DateTime? ToUtc(DateTime? zoneDateTime, string timeZoneId,
-        IDateTimeZoneProvider? timeZoneProvider, ZoneLocalMappingResolver? resolver = null)
-    {
-        if (!zoneDateTime.HasValue) return null;
-
-        timeZoneProvider ??= DateTimeZoneProviders.Tzdb;
-        // never throws an exception due to ambiguity or skipped time:
-        resolver ??= Resolvers.LenientResolver;
-        // throws if timeZoneId is unknown
-        var timeZone = timeZoneProvider[timeZoneId];
-
-        var local = LocalDateTime.FromDateTime(zoneDateTime.Value);
-        var zonedTime = timeZone.ResolveLocal(local, resolver);
-        return zonedTime.ToDateTimeUtc();
-    }
-
-    /// <summary>
-    /// Converts the <see cref="DateTime"/> of any <see cref="DateTimeKind"/> to a <see cref="DateTime"/> of <see cref="DateTimeKind.Utc"/>.
-    /// </summary>
-    /// <param name="zoneDateTime"></param>
-    /// <param name="timeZoneId">The ID of the IANA timezone database, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.</param>
-    /// <param name="timeZoneProvider"></param>
-    /// <param name="resolver">The <see cref="ZoneLocalMappingResolver"/> to use. Default is <see cref="Resolvers.LenientResolver"/>´, which never throws an exception due to ambiguity or skipped time.</param>
-    /// <returns>Returns the converted <see cref="DateTime"/> with <see cref="DateTimeKind.Utc"/>.</returns>
-    /// <exception cref="DateTimeZoneNotFoundException">If <paramref name="timeZoneId"/> is unknown.</exception>
-    public static DateTime ToUtc(DateTime zoneDateTime, string timeZoneId,
-        IDateTimeZoneProvider timeZoneProvider, ZoneLocalMappingResolver? resolver = null)
-    {
-        return ToUtc((DateTime?)zoneDateTime, timeZoneId, timeZoneProvider, resolver)!.Value;
-    }
-        
     /// <summary>
     /// Checks whether the Windows <see cref="TimeZoneInfo"/> can be mapped to a IANA timezone ID.
     /// </summary>
@@ -278,17 +196,34 @@ public class TimeZoneConverter
     /// <returns>Returns <c>true</c> if the <see cref="TimeZoneInfo"/> can be mapped to a IANA timezone, otherwise <c>false</c>.</returns>
     public static bool CanMapToIanaTimeZone(TimeZoneInfo timeZoneInfo)
     {
-        return TzConverter.TZConvert.TryWindowsToIana(timeZoneInfo.Id, out _);
+        return TimeZoneInfo.TryConvertWindowsIdToIanaId(timeZoneInfo.Id, out _);
     }
 
     /// <summary>
-    /// Get a collection of available <see cref="IDateTimeZoneProvider.Ids"/>.
+    /// Get a collection of available <see cref="TimeZoneInfo.Id"/>s.
     /// </summary>
-    /// <param name="timeZoneProvider">The <see cref="IDateTimeZoneProvider"/> to use. Default is <see cref="DateTimeZoneProviders.Tzdb"/>.</param>
-    /// <returns>Returns a collection of available <see cref="IDateTimeZoneProvider.Ids"/>.</returns>
-    public static IReadOnlyCollection<string> GetTimeZoneList(IDateTimeZoneProvider? timeZoneProvider = null)
+    /// <returns>Returns a collection of available <see cref="TimeZoneInfo.Id"/>s.</returns>
+    public static IReadOnlyCollection<string> GetSystemTimeZoneList()
     {
-        timeZoneProvider ??= DateTimeZoneProviders.Tzdb;
-        return timeZoneProvider.Ids;
+        return TimeZoneInfo.GetSystemTimeZones().Select(tz => tz.Id).ToList().AsReadOnly();
+    }
+
+    /// <summary>
+    /// Get a collection of IANA Ids for <see cref="TimeZoneInfo"/>s that can be converted to IANA.
+    /// </summary>
+    /// <returns>A collection of IANA Ids for <see cref="TimeZoneInfo"/>s that can be converted to IANA.</returns>
+    public static IReadOnlyCollection<string> GetIanaTimeZoneList()
+    {
+        var ianaTimeZones = new List<string>();
+
+        foreach (var timeZone in TimeZoneInfo.GetSystemTimeZones())
+        {
+            if (TimeZoneInfo.TryConvertWindowsIdToIanaId(timeZone.Id, out var ianaTimeZoneId))
+            {
+                ianaTimeZones.Add(ianaTimeZoneId);
+            }
+        }
+
+        return ianaTimeZones.AsReadOnly();
     }
 }

--- a/Axuno.Tools/DateAndTime/TimeZoneConverter.cs
+++ b/Axuno.Tools/DateAndTime/TimeZoneConverter.cs
@@ -71,7 +71,7 @@ public class TimeZoneConverter
         return ToUtc(zoneDateTime, _ianaTimeZoneId);
     }
 
-    public DateTime? ToUtc(DateTime? zoneDateTime, string timeZoneId)
+    public static DateTime? ToUtc(DateTime? zoneDateTime, string timeZoneId)
     {
         if (!zoneDateTime.HasValue) return null;
 
@@ -94,7 +94,7 @@ public class TimeZoneConverter
     /// <param name="timeZoneId">The ID of the IANA timezone database, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.</param>
     /// <returns>Returns the converted <see cref="DateTime"/> with <see cref="DateTimeKind.Utc"/>.</returns>
     /// <exception cref="TimeZoneNotFoundException">If <paramref name="timeZoneId"/> is unknown.</exception>
-    public DateTime ToUtc(DateTime zoneDateTime, string timeZoneId)
+    public static DateTime ToUtc(DateTime zoneDateTime, string timeZoneId)
     {
         return (DateTime) ToUtc((DateTime?) zoneDateTime, timeZoneId)!;
     }

--- a/Axuno.Tools/DateAndTime/ZonedTime.cs
+++ b/Axuno.Tools/DateAndTime/ZonedTime.cs
@@ -11,24 +11,16 @@ public class ZonedTime : IZonedTimeInfo
     {
     }
 
-    /// <summary>
-    /// Gets the <see cref="CultureInfo"/> used for localization.
-    /// </summary>
+    /// <inheritdoc />
     public CultureInfo CultureInfo { get; internal set; } = CultureInfo.InvariantCulture;
 
-    /// <summary>
-    /// Gets the IANA timezone ID related to the <see cref="DateTimeOffset"/>.
-    /// </summary>
+    /// <inheritdoc />
     public string TimeZoneId { get; internal set; } = string.Empty;
 
-    /// <summary>
-    /// Gets the <see cref="DateTimeOffset"/> which is set based on the timezone offset to UTC.
-    /// </summary>
+    /// <inheritdoc />
     public DateTimeOffset DateTimeOffset { get; internal set; }
 
-    /// <summary>
-    /// Gets the generic name for the time zone.
-    /// </summary>
+    /// <inheritdoc/>
     public string GenericName { get; internal set; } = string.Empty;
 
     /// <summary>
@@ -41,23 +33,15 @@ public class ZonedTime : IZonedTimeInfo
     /// </summary>
     public string DisplayName { get; internal set; } = string.Empty;
 
-    /// <summary>
-    /// Gets the name of the timezone related to the <see cref="DateTimeOffset"/>.
-    /// </summary>
+    /// <inheritdoc/>
     public string Name { get; internal set; } = string.Empty;
 
-    /// <summary>
-    /// Gets the timezone abbreviation related to the <see cref="DateTimeOffset"/>.
-    /// </summary>
+    /// <inheritdoc/>
     public string Abbreviation { get; internal set; } = string.Empty;
 
-    /// <summary>
-    /// Gets whether the timezone related to the <see cref="DateTimeOffset"/> is daylight saving time.
-    /// </summary>
+    /// <inheritdoc/>
     public bool IsDaylightSavingTime { get; internal set; }
 
-    /// <summary>
-    /// Gets the time difference between the current time zone's standard time and Coordinated Universal Time (UTC).
-    /// </summary>
+    /// <inheritdoc/>
     public TimeSpan BaseUtcOffset { get; internal set; }
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,8 @@
         <Copyright>Copyright 2011-$(CurrentYear) axuno gGmbH</Copyright>
         <RepositoryUrl>https://github.com/axuno/Volleyball-League</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <Version>7.0.1</Version>
-        <FileVersion>7.0.0</FileVersion>
+        <Version>7.2.1</Version>
+        <FileVersion>7.2.1</FileVersion>
         <AssemblyVersion>7.0.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>

--- a/League.Tests/TestComponents/UnitTestHelpers.cs
+++ b/League.Tests/TestComponents/UnitTestHelpers.cs
@@ -115,9 +115,7 @@ public class UnitTestHelpers
             })
             .AddLocalization()
             .AddSingleton(sp => new Axuno.Tools.DateAndTime.TimeZoneConverter(
-                sp.GetRequiredService<NodaTime.TimeZones.DateTimeZoneCache>(), "Europe/Berlin",
-                CultureInfo.CurrentCulture,
-                NodaTime.TimeZones.Resolvers.LenientResolver))
+                "Europe/Berlin", CultureInfo.CurrentCulture))
             .AddTransient<ITenantContext>(sp => tenantContext)
             .AddTextTemplatingModule(vfs =>
                 {

--- a/League/LeagueStartup.cs
+++ b/League/LeagueStartup.cs
@@ -452,14 +452,10 @@ public static class LeagueStartup
 
         #region ** Timezone service per request **
 
-        services.AddSingleton<NodaTime.TimeZones.DateTimeZoneCache>(sp =>
-            new NodaTime.TimeZones.DateTimeZoneCache(NodaTime.TimeZones.TzdbDateTimeZoneSource.Default));
-
-        var tzId = configuration.GetSection("TimeZone").Value ?? "America/New_York";
+        var ianaTzId = configuration.GetSection("TimeZone").Value ?? "America/New_York";
         // TimeZoneConverter will use the culture of the current scope
         services.AddScoped(sp => new Axuno.Tools.DateAndTime.TimeZoneConverter(
-            sp.GetRequiredService<NodaTime.TimeZones.DateTimeZoneCache>(), tzId, CultureInfo.CurrentCulture,
-            NodaTime.TimeZones.Resolvers.LenientResolver));
+            ianaTzId, CultureInfo.CurrentCulture));
 
         #endregion
 

--- a/League/TextTemplatingModule/TextTemplatingServiceCollectionExtensions.cs
+++ b/League/TextTemplatingModule/TextTemplatingServiceCollectionExtensions.cs
@@ -38,15 +38,11 @@ public static class TextTemplatingServiceCollectionExtensions
         services.TryAddSingleton(typeof(IStringLocalizer<>), typeof(StringLocalizer<>));
 
         #region ** Timezone service **
-
-        services.TryAddSingleton<NodaTime.TimeZones.DateTimeZoneCache>(sp =>
-            new NodaTime.TimeZones.DateTimeZoneCache(NodaTime.TimeZones.TzdbDateTimeZoneSource.Default));
             
-        var tzId = "America/New_York"; // America/New_York
+        var ianaTzId = "America/New_York"; // America/New_York
         // TimeZoneConverter will use the culture of the current scope
         services.TryAddTransient<Axuno.Tools.DateAndTime.TimeZoneConverter>(sp => new Axuno.Tools.DateAndTime.TimeZoneConverter(
-            sp.GetRequiredService<NodaTime.TimeZones.DateTimeZoneCache>(), tzId, CultureInfo.GetCultureInfo("en"),
-            NodaTime.TimeZones.Resolvers.LenientResolver));
+            ianaTzId, CultureInfo.GetCultureInfo("en")));
 
         #endregion
             

--- a/League/Views/Match/Results.cshtml
+++ b/League/Views/Match/Results.cshtml
@@ -81,7 +81,7 @@
                                 const string unknown = "-";
                                 var matches = Model.CompletedMatches.Where(m => m.RoundId == r.RoundId).OrderBy(m => m.RoundLegSequenceNo).ThenBy(m => m.MatchDate).ToList();
                                 var legs = matches.GroupBy(m => m.RoundLegSequenceNo).ToList();
-                                Axuno.Tools.DateAndTime.ZonedTime? zonedTime;
+                                Axuno.Tools.DateAndTime.IZonedTimeInfo? zonedTime;
                                 for (var i = 0; i < matches.Count; i++)
                                 {
                                     var match = matches[i];

--- a/TournamentManager/TournamentManager.Tests/Importers/ExcludeDates/ExcelImporterTests.cs
+++ b/TournamentManager/TournamentManager.Tests/Importers/ExcludeDates/ExcelImporterTests.cs
@@ -17,9 +17,7 @@ public class ExcelImporterTests
         var xlFilePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Assets", "ExcludedDates.xlsx");
         // using CET as time zone
         var tzConverter = new Axuno.Tools.DateAndTime.TimeZoneConverter(
-            new NodaTime.TimeZones.DateTimeZoneCache(NodaTime.TimeZones.TzdbDateTimeZoneSource.Default), "Europe/Berlin",
-            CultureInfo.CurrentCulture,
-            NodaTime.TimeZones.Resolvers.LenientResolver);
+            "Europe/Berlin", CultureInfo.CurrentCulture);
         var xlImporter = new ExcelImporter(xlFilePath, tzConverter, NullLogger<ExcelImporter>.Instance);
 
         var imported = xlImporter.Import(new DateTimePeriod(from, to)).ToList();
@@ -36,9 +34,7 @@ public class ExcelImporterTests
         var xlFilePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Assets", "ExcludedDates.xlsx");
         // Using UTC as time zone
         var tzConverter = new Axuno.Tools.DateAndTime.TimeZoneConverter(
-            new NodaTime.TimeZones.DateTimeZoneCache(NodaTime.TimeZones.TzdbDateTimeZoneSource.Default), "UTC",
-            CultureInfo.CurrentCulture,
-            NodaTime.TimeZones.Resolvers.LenientResolver);
+            "UTC", CultureInfo.CurrentCulture);
         var xlImporter = new ExcelImporter(xlFilePath, tzConverter, NullLogger<ExcelImporter>.Instance);
 
         var imported = xlImporter.Import(new DateTimePeriod(from, to)).ToList();

--- a/TournamentManager/TournamentManager.Tests/Importers/ExcludeDates/GermanHolidayImporterTests.cs
+++ b/TournamentManager/TournamentManager.Tests/Importers/ExcludeDates/GermanHolidayImporterTests.cs
@@ -16,9 +16,7 @@ public class GermanHolidayImporterTests
     {
         // using CET as time zone
         var tzConverter = new Axuno.Tools.DateAndTime.TimeZoneConverter(
-            new NodaTime.TimeZones.DateTimeZoneCache(NodaTime.TimeZones.TzdbDateTimeZoneSource.Default), "Europe/Berlin",
-            CultureInfo.CurrentCulture,
-            NodaTime.TimeZones.Resolvers.LenientResolver);
+            "Europe/Berlin", CultureInfo.CurrentCulture);
         var holidayFilter = new Predicate<GermanHoliday>(h => h.Type == GermanHolidays.Type.Public && h.PublicHolidayStateIds.Count == new GermanFederalStates().Count);
         var hImporter = new GermanHolidayImporter(null, holidayFilter, tzConverter, NullLogger<GermanHolidayImporter>.Instance);
 
@@ -34,9 +32,7 @@ public class GermanHolidayImporterTests
     {
         // using CET as time zone
         var tzConverter = new Axuno.Tools.DateAndTime.TimeZoneConverter(
-            new NodaTime.TimeZones.DateTimeZoneCache(NodaTime.TimeZones.TzdbDateTimeZoneSource.Default), "Europe/Berlin",
-            CultureInfo.CurrentCulture,
-            NodaTime.TimeZones.Resolvers.LenientResolver);
+            "Europe/Berlin", CultureInfo.CurrentCulture);
         var holidayFilter = new Predicate<GermanHoliday>(h => h.Type == GermanHolidays.Type.Public && h.PublicHolidayStateIds.Contains(GermanFederalStates.Id.Bayern));
         var hImporter = new GermanHolidayImporter(null, holidayFilter, tzConverter, NullLogger<GermanHolidayImporter>.Instance);
 
@@ -52,9 +48,7 @@ public class GermanHolidayImporterTests
     {
         // using CET as time zone
         var tzConverter = new Axuno.Tools.DateAndTime.TimeZoneConverter(
-            new NodaTime.TimeZones.DateTimeZoneCache(NodaTime.TimeZones.TzdbDateTimeZoneSource.Default), "Europe/Berlin",
-            CultureInfo.CurrentCulture,
-            NodaTime.TimeZones.Resolvers.LenientResolver);
+            "Europe/Berlin", CultureInfo.CurrentCulture);
         var holidayFilter = new Predicate<GermanHoliday>(
             h =>
                 h.Type == GermanHolidays.Type.Public &&
@@ -80,9 +74,7 @@ public class GermanHolidayImporterTests
         var customHolidayFilePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Assets", "Custom_Holidays_Sample.xml");
         // using CET as time zone
         var tzConverter = new Axuno.Tools.DateAndTime.TimeZoneConverter(
-            new NodaTime.TimeZones.DateTimeZoneCache(NodaTime.TimeZones.TzdbDateTimeZoneSource.Default), "Europe/Berlin",
-            CultureInfo.CurrentCulture,
-            NodaTime.TimeZones.Resolvers.LenientResolver);
+            "Europe/Berlin", CultureInfo.CurrentCulture);
         var holidayFilter = new Predicate<GermanHoliday>(h => h.Type == GermanHolidays.Type.School);
         var hImporter = new GermanHolidayImporter(customHolidayFilePath, holidayFilter, tzConverter, NullLogger<GermanHolidayImporter>.Instance);
 

--- a/TournamentManager/TournamentManager.Tests/Importers/ExcludeDates/InternetCalendarImporterTests.cs
+++ b/TournamentManager/TournamentManager.Tests/Importers/ExcludeDates/InternetCalendarImporterTests.cs
@@ -16,9 +16,7 @@ public class InternetCalendarImporterTests
         var icsFilePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Assets", "School_Holidays_Bavaria_2024.ics");
         // using CET as time zone
         var tzConverter = new Axuno.Tools.DateAndTime.TimeZoneConverter(
-            new NodaTime.TimeZones.DateTimeZoneCache(NodaTime.TimeZones.TzdbDateTimeZoneSource.Default), "Europe/Berlin",
-            CultureInfo.CurrentCulture,
-            NodaTime.TimeZones.Resolvers.LenientResolver);
+            "Europe/Berlin", CultureInfo.CurrentCulture);
 
         var icsImporter = new InternetCalendarImporter(File.ReadAllText(icsFilePath, Encoding.UTF8), "Europe/Berlin", NullLogger<InternetCalendarImporter>.Instance);
 

--- a/TournamentManager/TournamentManager.Tests/ModelValidators/FixtureValidatorTests.cs
+++ b/TournamentManager/TournamentManager.Tests/ModelValidators/FixtureValidatorTests.cs
@@ -23,9 +23,7 @@ public class FixtureValidatorTests
     {
         #region *** TimeZoneConverter ***
 
-        var tzProvider = new NodaTime.TimeZones.DateTimeZoneCache(NodaTime.TimeZones.TzdbDateTimeZoneSource.Default);
-        var tzId = "Europe/Berlin";
-        _data.TimeZoneConverter = new Axuno.Tools.DateAndTime.TimeZoneConverter(tzProvider, tzId, _culture, NodaTime.TimeZones.Resolvers.LenientResolver);
+        _data.TimeZoneConverter = new Axuno.Tools.DateAndTime.TimeZoneConverter("Europe/Berlin", _culture);
 
         #endregion
 

--- a/TournamentManager/TournamentManager.Tests/ModelValidators/MatchResultValidatorTests.cs
+++ b/TournamentManager/TournamentManager.Tests/ModelValidators/MatchResultValidatorTests.cs
@@ -17,9 +17,7 @@ public class MatchResultValidatorTests
     {
         #region *** TimeZoneConverter ***
 
-        var tzProvider = new NodaTime.TimeZones.DateTimeZoneCache(NodaTime.TimeZones.TzdbDateTimeZoneSource.Default);
-        var tzId = "Europe/Berlin";
-        _data.TimeZoneConverter = new Axuno.Tools.DateAndTime.TimeZoneConverter(tzProvider, tzId, System.Globalization.CultureInfo.GetCultureInfo("en-US"), NodaTime.TimeZones.Resolvers.LenientResolver);
+        _data.TimeZoneConverter = new Axuno.Tools.DateAndTime.TimeZoneConverter("Europe/Berlin", System.Globalization.CultureInfo.GetCultureInfo("en-US"));
 
         #endregion
 

--- a/TournamentManager/TournamentManager.Tests/Plan/AvailableMatchDatesTests.cs
+++ b/TournamentManager/TournamentManager.Tests/Plan/AvailableMatchDatesTests.cs
@@ -80,9 +80,7 @@ internal class AvailableMatchDatesTests
         // Create AvailableMatchDates instance
         var logger = NullLogger<AvailableMatchDates>.Instance;
         var tzConverter = new Axuno.Tools.DateAndTime.TimeZoneConverter(
-            new NodaTime.TimeZones.DateTimeZoneCache(NodaTime.TimeZones.TzdbDateTimeZoneSource.Default), "Europe/Berlin",
-            CultureInfo.CurrentCulture,
-            NodaTime.TimeZones.Resolvers.LenientResolver);
+            "Europe/Berlin", CultureInfo.CurrentCulture);
         var availableMatchDates = new AvailableMatchDates(tenantContextMock.Object, tzConverter, logger);
         return availableMatchDates;
     }

--- a/TournamentManager/TournamentManager.Tests/Plan/MatchSchedulerTests.cs
+++ b/TournamentManager/TournamentManager.Tests/Plan/MatchSchedulerTests.cs
@@ -193,9 +193,7 @@ internal class MatchSchedulerTests
         // Create MatchScheduler instance
         var logger = NullLogger<MatchScheduler>.Instance;
         var tzConverter = new Axuno.Tools.DateAndTime.TimeZoneConverter(
-            new NodaTime.TimeZones.DateTimeZoneCache(NodaTime.TimeZones.TzdbDateTimeZoneSource.Default), "Europe/Berlin",
-            CultureInfo.CurrentCulture,
-            NodaTime.TimeZones.Resolvers.LenientResolver);
+            "Europe/Berlin", CultureInfo.CurrentCulture);
         
         _tenantContext = tenantContextMock.Object;
         _tenantContext.TournamentContext.MatchPlanTournamentId = 1;


### PR DESCRIPTION
* Refactor the `TimeZoneConverter` class to eliminate dependencies on the `NodaTime` library, now using `TimeZoneInfo` from NET8.0 framework.
* Simplify the constructor to require only an IANA timezone ID and an optional `CultureInfo` object.
* Update `ToZonedTime` and `ToUtc` methods for timezone conversions using `TimeZoneInfo`.
* Replace `ZonedTime` return value with `IZonedTimeInfo` interface.
* Remove `NodaTime` package reference from `Axuno.Tools.csproj`.
* Add `GetSystemTimeZoneList`, `GetIanaTimeZoneList`, and `CanMapToIanaTimeZone` methods.
* Update `IZonedTimeInfo` interface with additional properties and fully qualified names.
* Update test methods to `TimeZoneConverterTests` for handling unknown timezone IDs and default culture usage.
* Update `TimeZoneConverterTests` to reflect the refactored `TimeZoneConverter` class.
* Bump version to v7.2.1