### PR TITLE
Replace Ical.Net package and update Calendar class

### DIFF
--- a/TournamentManager/TournamentManager/Match/Calendar.cs
+++ b/TournamentManager/TournamentManager/Match/Calendar.cs
@@ -13,34 +13,14 @@ public class Calendar
 
     public Calendar()
     {
-        _calendar.ProductId = "TournamentManager/Ical.Net";
+        _calendar.ProductId = "TournamentManager/Ical.Net"; // Does not appear in output
 
-        //Organizer = new Organizer() { CommonName = "TournamentManager", Value = new Uri("mailto:noreply@tournamentmanager")};
-
-        // Does not work well:
-        //_calendar.AddTimeZone(new VTimeZone("Europe/Berlin")); // TzId string NodaTime is aware of
+        // Don't use this: Organizer = new Organizer() { CommonName = "TournamentManager", Value = new Uri("mailto:noreply@tournamentmanager")};
+        // Does not work well: _calendar.AddTimeZone(new VTimeZone("Europe/Berlin"));
 
         FirstAlarm = new TimeSpan(-7, 0, 0, 0, 0);
         SecondAlarm = new TimeSpan(-1, 0, 0, 0, 0);
     }
-
-    protected string ProductId
-    {
-        set
-        {
-            _calendar.ProductId = value;
-        }
-
-        get
-        {
-            return _calendar.ProductId;
-        }
-    }
-
-    /*
-    public Organizer Organizer
-    { get; set; }
-    */
 
     /// <summary>
     /// The name of the calendar. Will be used by calendar clients. Default: Tournament Calendar 
@@ -94,7 +74,7 @@ public class Calendar
     /// <returns>Returns a <see cref="Ical.Net.Calendar"/> instance.</returns>
     public Calendar CreateEvents(List<CalendarRow> matches)
     {
-        //_calendar.Method = "PUBLISH";     // Matches.RealStart.HasValue ? "CANCEL" : "REQUEST";
+        // Don't set Calendar.Method to "PUBLISH"
         if (matches.Count > 1)
         {
             _calendar.AddProperty("NAME", Name);
@@ -105,7 +85,6 @@ public class Calendar
         {
             var evt = _calendar.Create<CalendarEvent>();
                 
-            //evt.Organizer = Organizer;
             evt.Summary = Summary;
             evt.Location = $"{match.VenueName}, {match.VenueStreet}, {match.VenuePostalCode} {match.VenueCity}";
             evt.Description = !string.IsNullOrWhiteSpace(DescriptionOpponentsFormat)
@@ -152,7 +131,7 @@ public class Calendar
                     }
                 );
             }
-            // _iCal.Events.Add(evt);  // this would double entries!!
+            // Adding 'evt' to Events would cause double entries
         }
         return this;
     }
@@ -217,7 +196,7 @@ public class Calendar
                     }
                 );
             }
-            // _iCal.Events.Add(evt);  // this would add double entries
+            // Adding 'evt' to Events would cause double entries
         }
         return this;
     }

--- a/TournamentManager/TournamentManager/TournamentManager.csproj
+++ b/TournamentManager/TournamentManager/TournamentManager.csproj
@@ -27,7 +27,8 @@ Volleyball League is an open source sports platform that brings everything neces
     <PackageReference Include="OxyPlot.SkiaSharp" Version="2.2.0" />
     <PackageReference Include="PuppeteerSharp" Version="20.0.2" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
-    <PackageReference Include="Ical.Net" Version="4.2.0" />
+    <!-- Replace original Ical.Net v4.2.0 with more up-to-date fork -->
+    <PackageReference Include="laget.Ical.Net" Version="4.3.9" />
     <PackageReference Include="libphonenumber-csharp" Version="8.13.46" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.3.14" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />


### PR DESCRIPTION
* Simplified ProductId property in Calendar class.
* Updated comments to clarify usage of Organizer property, AddTimeZone method, and _calendar.Method property.
* Clarified comments in CreateEvents and CreatePublicCalendar methods to prevent duplicate entries.
* Updated TournamentManager.csproj to use laget.Ical.Net version 4.3.9 instead of outdated original Ical.Net v4.2.0