### PR TITLE
Update nuget pkg, bump version to v7.2.3

### DIFF
--- a/Axuno.BackgroundTask/Axuno.BackgroundTask.csproj
+++ b/Axuno.BackgroundTask/Axuno.BackgroundTask.csproj
@@ -17,6 +17,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
   </ItemGroup>
 </Project>

--- a/Axuno.Web/Axuno.Web.csproj
+++ b/Axuno.Web/Axuno.Web.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.1.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.1.2" />
     <PackageReference Include="NuGetizer" Version="1.2.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,8 @@
         <Copyright>Copyright 2011-$(CurrentYear) axuno gGmbH</Copyright>
         <RepositoryUrl>https://github.com/axuno/Volleyball-League</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <Version>7.2.2</Version>
-        <FileVersion>7.2.2</FileVersion>
+        <Version>7.2.3</Version>
+        <FileVersion>7.2.3</FileVersion>
         <AssemblyVersion>7.0.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>

--- a/League.Tests/League.Tests.csproj
+++ b/League.Tests/League.Tests.csproj
@@ -5,8 +5,8 @@
     <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
+    <PackageReference Include="Azure.Identity" Version="1.13.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
@@ -19,10 +19,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.10" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="ObjectsComparer" Version="1.4.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\League.Demo\League.Demo.csproj" />

--- a/League/League.csproj
+++ b/League/League.csproj
@@ -67,16 +67,16 @@ Localizations for English and German are included. The library is in operation o
         <PackageReference Include="Axuno.TextTemplating" Version="2.1.0" />
         <PackageReference Include="JSNLog" Version="3.0.3" />
         <PackageReference Include="MailMergeLib" Version="5.12.3" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.8" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.8" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.8" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.10" />
         <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.5" />
+        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.6" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="NLog" Version="5.3.4" />
         <PackageReference Include="NLog.Web.AspNetCore" Version="5.3.14" />
@@ -88,7 +88,7 @@ Localizations for English and German are included. The library is in operation o
         <PackageReference Include="StackifyMiddleware" Version="3.3.3.4767" />
         <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.1" />
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.2" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
     <ItemGroup>

--- a/TournamentManager/DAL/DatabaseGeneric/TournamentManager.DAL.DbGeneric.csproj
+++ b/TournamentManager/DAL/DatabaseGeneric/TournamentManager.DAL.DbGeneric.csproj
@@ -12,6 +12,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SD.LLBLGen.Pro.ORMSupportClasses" Version="5.11.2" />
+    <PackageReference Include="SD.LLBLGen.Pro.ORMSupportClasses" Version="5.11.3" />
   </ItemGroup>
 </Project>

--- a/TournamentManager/DAL/DatabaseSpecific/TournamentManager.DAL.DBSpecific.csproj
+++ b/TournamentManager/DAL/DatabaseSpecific/TournamentManager.DAL.DBSpecific.csproj
@@ -11,6 +11,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SD.LLBLGen.Pro.DQE.SqlServer" Version="5.11.2" />
+    <PackageReference Include="SD.LLBLGen.Pro.DQE.SqlServer" Version="5.11.3" />
   </ItemGroup>
 </Project>

--- a/TournamentManager/TournamentManager/TournamentManager.csproj
+++ b/TournamentManager/TournamentManager/TournamentManager.csproj
@@ -32,7 +32,6 @@ Volleyball League is an open source sports platform that brings everything neces
     <PackageReference Include="libphonenumber-csharp" Version="8.13.47" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.3.14" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="YAXLib" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Updated the following packages:
- `Microsoft.Extensions.Hosting` to `8.0.1` in `Axuno.BackgroundTask.csproj`
- `Microsoft.IdentityModel.Tokens` to `8.1.2` in `Axuno.Web.csproj`
- `Azure.Identity` to `1.13.0` in `League.Tests.csproj`
- `Microsoft.AspNetCore.Mvc.Testing` to `8.0.10` in `League.Tests.csproj`
- `Microsoft.AspNetCore.TestHost` to `8.0.10` in `League.Tests.csproj`
- `System.IdentityModel.Tokens.Jwt` to `8.1.2` in `League.Tests.csproj`
- `Microsoft.AspNetCore.Authentication.Facebook`, `Google`, `MicrosoftAccount`, and `Razor.RuntimeCompilation` to `8.0.10` in `League.csproj`
- `Microsoft.VisualStudio.Web.CodeGeneration.Design` to `8.0.6` in `League.csproj`
- `System.Security.Cryptography.Xml` to `8.0.2` in `League.csproj`
- `SD.LLBLGen.Pro.ORMSupportClasses` to `5.11.3` in `TournamentManager.DAL.DbGeneric.csproj`
- `SD.LLBLGen.Pro.DQE.SqlServer` to `5.11.3` in `TournamentManager.DAL.DBSpecific.csproj`

Also updated `Version` and `FileVersion` properties to `7.2.3` in `Directory.Build.props`.