### PR TITLE
Update major package versions of Identity and Cryptography.Xml

### DIFF
--- a/League.Tests/League.Tests.csproj
+++ b/League.Tests/League.Tests.csproj
@@ -5,7 +5,7 @@
     <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Azure.Identity" Version="1.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.10" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="ObjectsComparer" Version="1.4.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\League.Demo\League.Demo.csproj" />

--- a/League/League.csproj
+++ b/League/League.csproj
@@ -87,7 +87,7 @@ Localizations for English and German are included. The library is in operation o
         </PackageReference>
         <PackageReference Include="StackifyMiddleware" Version="3.3.3.4767" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.0" />
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.5" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
Updated `Azure.Identity` to 1.14.0, `System.IdentityModel.Tokens.Jwt` to 8.12.0 and `System.Security.Cryptography.Xml` to 9.0.5 in the respective project files.