### PR TITLE
`TournamentCreator` can now also copy teams from another tournament

### DIFF
--- a/TournamentManager/TournamentManager/TournamentCreator.cs
+++ b/TournamentManager/TournamentManager/TournamentCreator.cs
@@ -21,6 +21,8 @@ public class TournamentCreator
     /// <param name="TargetDescription">The description for the target tournament.</param>
     /// <param name="TargetLegDates">The leg dates to use for the target tournament round legs. The list cover maximum number of legs across akk rounds.</param>
     /// <param name="RoundsToExclude">The round IDs to exclude from copy.</param>
+    /// <param name="CopyTeamsFromSource">true if teams of each round shall be copied.</param>
+    /// <param name="TeamsToExclude">The team IDs to exclude from copy.</param>
     /// <param name="DisableChecks">Disable safety checks.</param>
     /// <param name="ModifiedOn">The <see cref="DateTime"/> to use for CreatedOn / ModifiedOn of entities.</param>
     public record CopyTournamentArgs(
@@ -28,16 +30,16 @@ public class TournamentCreator
         bool SetSourceTournamentCompleted,
         string TargetName,
         string? TargetDescription,
-        IList<(DateTime Start, DateTime End)> TargetLegDates,
-        IList<long> RoundsToExclude,
+        List<(DateTime Start, DateTime End)> TargetLegDates,
+        List<long> RoundsToExclude,
+        bool CopyTeamsFromSource,
+        List<long> TeamsToExclude,
         bool DisableChecks,
         DateTime ModifiedOn);
 
     private readonly ILogger<TournamentCreator> _logger;
     private readonly IAppDb _appDb;
-    private DateTime _modifiedOn;
     private static TournamentCreator? _instance;
-
 
     private TournamentCreator(IAppDb appDb, ILogger<TournamentCreator> logger)
     {
@@ -64,10 +66,11 @@ public class TournamentCreator
     /// <param name="cancellationToken"></param>
     /// <code>
     /// var copyArgs = new TournamentCreator.CopyTournamentArgs(25, false, "Tournament 2024/25", null,
-    /// new List&lt;(DateTime Start, DateTime End)&gt; {
-    ///    (new DateTime(2024, 9, 23), new DateTime(2025, 2, 1)), // 1st leg
-    ///    (new DateTime(2025, 2, 3), new DateTime(2025, 5, 30))  // 2nd leg
-    /// }, Array.Empty&lt;long&gt;(), false, DateTime.UtcNow);
+    /// [
+    ///     (new DateTime(2025, 9, 22), new DateTime(2026, 1, 31, 23, 59,59)), // 1st leg
+    ///     (new DateTime(2026, 2, 1), new DateTime(2026, 5, 30, 23, 59, 59))  // 2nd leg
+    /// ],
+    /// [], false, [], false, DateTime.UtcNow);
     ///         
     /// var success = await TournamentCreator
     ///    .Instance(AppDb, AppLogging.CreateLogger&lt;TournamentCreator&gt;())
@@ -77,10 +80,11 @@ public class TournamentCreator
     /// <exception cref="InvalidOperationException"></exception>
     public async Task<bool> CreateNewFromSourceTournament(CopyTournamentArgs copyArgs, CancellationToken cancellationToken)
     {
-        _modifiedOn = copyArgs.ModifiedOn;
-        if (copyArgs.SetSourceTournamentCompleted) await SetTournamentCompleted(copyArgs.SourceTournamentId, cancellationToken);
+        if (copyArgs.SetSourceTournamentCompleted)
+            await SetTournamentCompleted(copyArgs.SourceTournamentId, copyArgs.ModifiedOn, cancellationToken);
 
-        var (sourceTournament, targetTournament) = await CopyTournament(copyArgs, cancellationToken);
+        var (sourceTournament, targetTournament) =
+            await CopyTournament(copyArgs, cancellationToken);
 
         var success = await CopyRoundsWithLegsToTarget(copyArgs, targetTournament, cancellationToken);
 
@@ -109,7 +113,6 @@ public class TournamentCreator
     /// <exception cref="InvalidOperationException"></exception>
     internal async Task<(TournamentEntity Source, TournamentEntity Target)> CopyTournament (CopyTournamentArgs copyArgs, CancellationToken cancellationToken)
     {
-        _modifiedOn = copyArgs.ModifiedOn;
         var sourceTournament =
             await _appDb.TournamentRepository.GetTournamentAsync(
                 new PredicateExpression(TournamentFields.Id == copyArgs.SourceTournamentId), CancellationToken.None)
@@ -140,8 +143,8 @@ public class TournamentCreator
             Description = copyArgs.TargetDescription,
             TypeId = sourceTournament.TypeId,
             IsComplete = false,
-            CreatedOn = _modifiedOn,
-            ModifiedOn = _modifiedOn,
+            CreatedOn = copyArgs.ModifiedOn,
+            ModifiedOn = copyArgs.ModifiedOn,
         };
 
         // Update the source tournament
@@ -161,7 +164,6 @@ public class TournamentCreator
     /// <returns>The <paramref name="targetTournament"/> <see cref="TournamentEntity"/> with rounds and round legs added.</returns>
     internal async Task<bool> CopyRoundsWithLegsToTarget(CopyTournamentArgs args, TournamentEntity targetTournament, CancellationToken cancellationToken)
     {
-        _modifiedOn = args.ModifiedOn;
         // get the round IDs of the SOURCE tournament
         var sourceRoundIds = await _appDb.TournamentRepository.GetTournamentRoundIdsAsync(args.SourceTournamentId, cancellationToken);
         
@@ -169,65 +171,112 @@ public class TournamentCreator
         {
             var sourceRound = await _appDb.RoundRepository.GetRoundWithLegsAsync(sourceRoundId, cancellationToken);
 
-            if (sourceRound is null)
-            {
-                _logger.LogError("Round {RoundId} not found.", sourceRoundId);
-                return false;
-            }
-
-            // skip excluded round id's
-            if (args.RoundsToExclude.Contains(sourceRoundId))
-            {
-                _logger.LogDebug("Round {RoundId} excluded from copy.", sourceRoundId);
+            if (!IsRoundValidForCopy(sourceRoundId, sourceRound, args))
                 continue;
-            }
 
-            // Create target round from the source round
-            var targetRound = new RoundEntity
-            {
-                Tournament = targetTournament, // this adds the round to the target tournament
-                Name = sourceRound.Name,
-                Description = sourceRound.Description,
-                TypeId = sourceRound.TypeId,
-                NumOfLegs = sourceRound.NumOfLegs,
-                MatchRuleId = sourceRound.MatchRuleId,
-                SetRuleId = sourceRound.SetRuleId,
-                IsComplete = false,
-                CreatedOn = _modifiedOn,
-                ModifiedOn = _modifiedOn,
-                NextRoundId = null
-            };
+            var targetRound = CreateTargetRound(sourceRound!, targetTournament, args);
 
-            var legDates = args.TargetLegDates;
-
-            if (sourceRound.RoundLegs.Count > legDates.Count)
-            {
-                _logger.LogError("Round {RoundId} has {Legs} legs, but only {LegDates} leg dates provided.", sourceRoundId, sourceRound.RoundLegs.Count, legDates.Count);
+            if (!CopyRoundLegs(sourceRound!, targetRound, args, sourceRoundId))
                 return false;
-            }
 
-            // Create the round leg records based on the TARGET tournament legs, but use new log dates
-            for (var index = 0; index < sourceRound.RoundLegs.Count; index++)
-            {
-                var rl = sourceRound.RoundLegs[index];
-                _ = new RoundLegEntity
-                {
-                    Round = targetRound, // this adds the round leg to the target round
-                    SequenceNo = rl.SequenceNo,
-                    Description = rl.Description,
-                    StartDateTime = legDates[index].Start,
-                    EndDateTime = legDates[index].End,
-                    CreatedOn = _modifiedOn,
-                    ModifiedOn = _modifiedOn
-                };
-            }
+            if (args.CopyTeamsFromSource)
+                await CopyTeamsInRound(sourceRoundId, targetRound, args, cancellationToken);
 
-            _logger.LogDebug("Round {RoundId} with {Legs} legs copied to target tournament.", sourceRoundId, sourceRound.RoundLegs.Count);
+            _logger.LogDebug("Target Round {RoundId} contains {TeamCount} teams.", targetRound.Id, targetRound.TeamInRounds.Count);
         }
 
         _logger.LogDebug("Target tournament contains {RoundCount} rounds.", targetTournament.Rounds.Count);
 
         return true;
+    }
+
+    private bool IsRoundValidForCopy(long sourceRoundId, RoundEntity? sourceRound, CopyTournamentArgs args)
+    {
+        if (sourceRound is null)
+        {
+            _logger.LogError("Round {RoundId} not found.", sourceRoundId);
+            return false;
+        }
+
+        if (args.RoundsToExclude.Contains(sourceRoundId))
+        {
+            _logger.LogDebug("Round {RoundId} excluded from copy.", sourceRoundId);
+            return false;
+        }
+
+        return true;
+    }
+
+    private RoundEntity CreateTargetRound(RoundEntity sourceRound, TournamentEntity targetTournament, CopyTournamentArgs args)
+    {
+        return new RoundEntity
+        {
+            Tournament = targetTournament, // this adds the round to the target tournament
+            Name = sourceRound.Name,
+            Description = sourceRound.Description,
+            TypeId = sourceRound.TypeId,
+            NumOfLegs = sourceRound.NumOfLegs,
+            MatchRuleId = sourceRound.MatchRuleId,
+            SetRuleId = sourceRound.SetRuleId,
+            IsComplete = false,
+            CreatedOn = args.ModifiedOn,
+            ModifiedOn = args.ModifiedOn,
+            NextRoundId = null
+        };
+    }
+
+    private bool CopyRoundLegs(RoundEntity sourceRound, RoundEntity targetRound, CopyTournamentArgs args, long sourceRoundId)
+    {
+        var legDates = args.TargetLegDates;
+
+        if (sourceRound.RoundLegs.Count > legDates.Count)
+        {
+            _logger.LogError("Round {RoundId} has {Legs} legs, but only {LegDates} leg dates provided.", sourceRoundId, sourceRound.RoundLegs.Count, legDates.Count);
+            return false;
+        }
+
+        for (var index = 0; index < sourceRound.RoundLegs.Count; index++)
+        {
+            var rl = sourceRound.RoundLegs[index];
+            _ = new RoundLegEntity
+            {
+                Round = targetRound, // this adds the round leg to the target round
+                SequenceNo = rl.SequenceNo,
+                Description = rl.Description,
+                StartDateTime = legDates[index].Start,
+                EndDateTime = legDates[index].End,
+                CreatedOn = args.ModifiedOn,
+                ModifiedOn = args.ModifiedOn
+            };
+        }
+        _logger.LogDebug("Round {RoundId} with {Legs} legs copied to target tournament.", sourceRoundId, sourceRound.RoundLegs.Count);
+        return true;
+    }
+
+    private async Task CopyTeamsInRound(long sourceRoundId, RoundEntity targetRound, CopyTournamentArgs args, CancellationToken cancellationToken)
+    {
+        var sourceRoundTeams = await _appDb.TeamInRoundRepository.GetTeamInRoundAsync(new PredicateExpression(TeamInRoundFields.RoundId == sourceRoundId), cancellationToken);
+        foreach (var srcTeamIdInRound in
+                 sourceRoundTeams.Select(sourceTeamsInRound => sourceTeamsInRound.TeamId))
+        {
+            if (args.TeamsToExclude.Contains(srcTeamIdInRound))
+            {
+                _logger.LogDebug("Team {TeamId} excluded from copy.", srcTeamIdInRound);
+                continue;
+            }
+
+            var filter = new PredicateExpression(TeamFields.Id == srcTeamIdInRound);
+            var sourceTeam = await _appDb.TeamRepository.GetTeamEntityAsync(filter, cancellationToken);
+
+            _ = new TeamInRoundEntity
+            {
+                Round = targetRound, // this adds the TeamInRound to the target round
+                TeamId = srcTeamIdInRound,
+                TeamNameForRound = sourceTeam!.Name,
+                CreatedOn = args.ModifiedOn,
+                ModifiedOn = args.ModifiedOn
+            };
+        }
     }
 
     /// <summary>
@@ -237,9 +286,10 @@ public class TournamentCreator
     /// <param name="sequenceNo"></param>
     /// <param name="start"></param>
     /// <param name="end"></param>
+    /// <param name="modifiedOn"></param>
     /// <param name="cancellationToken"></param>
     /// <returns><see langword="true"/>, if successful.</returns>
-    public async Task<bool> SetLegDates(ICollection<RoundEntity> rounds , int sequenceNo, DateTime start, DateTime end, CancellationToken cancellationToken)
+    public async Task<bool> SetLegDates(ICollection<RoundEntity> rounds, int sequenceNo, DateTime start, DateTime end, DateTime modifiedOn, CancellationToken cancellationToken)
     {
         if (rounds.Count == 0)
             return false;
@@ -263,7 +313,7 @@ public class TournamentCreator
                 {
                     leg.StartDateTime = start;
                     leg.EndDateTime = end;
-                    leg.ModifiedOn = _modifiedOn;
+                    leg.ModifiedOn = modifiedOn;
 
                     await _appDb.GenericRepository.SaveEntityAsync(leg, false, false, cancellationToken);
                     _logger.LogDebug("RoundLeg {RoundLegId} updated with new dates.", leg.Id);
@@ -284,9 +334,10 @@ public class TournamentCreator
     /// If all matches of a tournament are completed, the rounds and the tournament are set to &quot;completed&quot;.
     /// </summary>
     /// <param name="tournamentId">The Tournament to be set as &quot;completed&quot;</param>
+    /// <param name="modifiedOn"></param>
     /// <param name="cancellationToken"></param>
     /// <exception cref="InvalidOperationException">Throws an exception if any match of the tournament is not completed yet.</exception>
-    public async Task SetTournamentCompleted(long tournamentId, CancellationToken cancellationToken)
+    public async Task SetTournamentCompleted(long tournamentId, DateTime modifiedOn, CancellationToken cancellationToken)
     {
         if (!await _appDb.MatchRepository.AllMatchesCompletedAsync(new TournamentEntity(tournamentId), cancellationToken))
         {
@@ -302,14 +353,14 @@ public class TournamentCreator
 
         foreach (var round in tournament.Rounds)
         {
-            round.ModifiedOn = _modifiedOn;
-            await SetRoundCompleted(round, cancellationToken);
+            round.ModifiedOn = modifiedOn;
+            await SetRoundCompleted(round, modifiedOn, cancellationToken);
         }
 
         if (!tournament.IsComplete)
         {
             tournament.IsComplete = true;
-            tournament.ModifiedOn = _modifiedOn;
+            tournament.ModifiedOn = modifiedOn;
             await _appDb.GenericRepository.SaveEntityAsync(tournament, false, false, cancellationToken);
             _logger.LogDebug("Tournament {Tournament} set as completed.", tournament);
         }
@@ -323,9 +374,10 @@ public class TournamentCreator
     /// Sets the specified round as completed if all matches of the round are completed.
     /// </summary>
     /// <param name="round">The round to be set as completed.</param>
+    /// <param name="modifiedOn"></param>
     /// <param name="cancellationToken"></param>
     /// <exception cref="InvalidOperationException">Thrown if any match of the round is not completed yet.</exception>
-    public virtual async Task SetRoundCompleted(RoundEntity round, CancellationToken cancellationToken)
+    public virtual async Task SetRoundCompleted(RoundEntity round, DateTime modifiedOn, CancellationToken cancellationToken)
     {
         if (!await _appDb.MatchRepository.AllMatchesCompletedAsync(round, cancellationToken))
         {
@@ -342,7 +394,7 @@ public class TournamentCreator
         if (!round.IsComplete)
         {
             round.IsComplete = true;
-            round.ModifiedOn = _modifiedOn;
+            round.ModifiedOn = modifiedOn;
 
             await _appDb.GenericRepository.SaveEntityAsync(round, false, false, cancellationToken);
             _logger.LogDebug("Round {RoundId} set as complete.", round.Id);


### PR DESCRIPTION
- Updated `CopyTournamentArgs` to include `CopyTeamsFromSource` and `TeamsToExclude`.
- Removed `_modifiedOn` field; replaced with `ModifiedOn` from `CopyTournamentArgs`.
- Modified `CreateNewFromSourceTournament` and `CopyTournament` to use `copyArgs.ModifiedOn`.
- Introduced `IsRoundValidForCopy`, `CopyRoundLegs`, and `CreateTargetRound` methods for better organization.
- Updated `SetLegDates`, `SetTournamentCompleted`, and `SetRoundCompleted` to accept `modifiedOn` parameter.