### PR TITLE
Update FluentAssertions to version 8.3.0

### DIFF
--- a/Axuno.BackgroundTask.Test/Axuno.BackgroundTask.Tests.csproj
+++ b/Axuno.BackgroundTask.Test/Axuno.BackgroundTask.Tests.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="FluentAssertions" Version="8.3.0" />
     <PackageReference Include="nunit" Version="4.3.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.9.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Axuno.Tools.Tests/Axuno.Tools.Tests.csproj
+++ b/Axuno.Tools.Tests/Axuno.Tools.Tests.csproj
@@ -20,7 +20,7 @@
     <EmbeddedResource Include="FileSystem\Data\my-json-file.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="FluentAssertions" Version="8.3.0" />
     <PackageReference Include="nunit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/League.Tests/League.Tests.csproj
+++ b/League.Tests/League.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Azure.Identity" Version="1.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="FluentAssertions" Version="8.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0">

--- a/TournamentManager/TournamentManager.Tests/TournamentManager.Tests.csproj
+++ b/TournamentManager/TournamentManager.Tests/TournamentManager.Tests.csproj
@@ -6,7 +6,7 @@
     <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="FluentAssertions" Version="8.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />


### PR DESCRIPTION
Updated the `FluentAssertions` package from version 7.0.0 to 8.3.0 in the following test project files:
- Axuno.BackgroundTask.Tests.csproj
- Axuno.Tools.Tests.csproj
- League.Tests.csproj
- TournamentManager.Tests.csproj