### PR TITLE
Update NLog packages and AspNetCore.TestHost

### DIFF
--- a/Axuno.BackgroundTask.Test/Axuno.BackgroundTask.Tests.csproj
+++ b/Axuno.BackgroundTask.Test/Axuno.BackgroundTask.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="8.3.0" />
     <PackageReference Include="nunit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.9.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.9.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Axuno.Tools.Tests/Axuno.Tools.Tests.csproj
+++ b/Axuno.Tools.Tests/Axuno.Tools.Tests.csproj
@@ -26,7 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.9.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.9.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Axuno.Web/Axuno.Web.csproj
+++ b/Axuno.Web/Axuno.Web.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.3.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.12.0" />
     <PackageReference Include="NuGetizer" Version="1.2.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/League.Tests/League.Tests.csproj
+++ b/League.Tests/League.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.14.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.17" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
     <PackageReference Include="FluentAssertions" Version="8.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
@@ -15,11 +15,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.9.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.9.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.17" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="ObjectsComparer" Version="1.4.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.0" />

--- a/League/League.csproj
+++ b/League/League.csproj
@@ -78,8 +78,8 @@ Localizations for English and German are included. The library is in operation o
         </PackageReference>
         <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="NLog" Version="5.3.4" />
-        <PackageReference Include="NLog.Web.AspNetCore" Version="5.3.15" />
+        <PackageReference Include="NLog" Version="5.5.0" />
+        <PackageReference Include="NLog.Web.AspNetCore" Version="5.5.0" />
         <PackageReference Include="NuGetizer" Version="1.2.4">
             <PrivateAssets>all</PrivateAssets>
             <PackEmbeddedResource>true</PackEmbeddedResource>

--- a/League/Models/MapViewModels/MapModel.cs
+++ b/League/Models/MapViewModels/MapModel.cs
@@ -80,7 +80,6 @@ public class MapModel
         }
 
         Locations = locationJsObject.ToString().TrimEnd(',', '\n');
-        return;
     }
 
     private static string ToJs(string input)

--- a/TournamentManager/TournamentManager.Tests/TournamentManager.Tests.csproj
+++ b/TournamentManager/TournamentManager.Tests/TournamentManager.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.9.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.9.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TournamentManager/TournamentManager/TournamentManager.csproj
+++ b/TournamentManager/TournamentManager/TournamentManager.csproj
@@ -19,7 +19,7 @@ Volleyball League is an open source sports platform that brings everything neces
   <ItemGroup>
     <PackageReference Include="EPPlus" Version="8.0.5" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
-    <PackageReference Include="NLog" Version="5.3.4" />
+    <PackageReference Include="NLog" Version="5.5.0" />
     <PackageReference Include="NuGetizer" Version="1.2.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -31,7 +31,7 @@ Volleyball League is an open source sports platform that brings everything neces
     <!-- Replace original Ical.Net v4.2.0 with more up-to-date fork -->
     <PackageReference Include="Ical.Net" Version="4.3.1" />
     <PackageReference Include="libphonenumber-csharp" Version="9.0.7" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.15" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.5.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
     <PackageReference Include="YAXLib" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
- Bump `NUnit.Analyzers` to version `4.9.1` across multiple test projects.
- Upgrade `Microsoft.IdentityModel.Tokens` to `8.12.0` in `Axuno.Web.csproj`.
- Update `Microsoft.AspNetCore.Mvc.Testing` to `8.0.17` in `League.Tests.csproj`.
- Upgrade `NLog` and `NLog.Web.AspNetCore` to `5.5.0` in relevant projects.
- Update `Microsoft.AspNetCore.TestHost` to `8.0.17` in `League.Tests.csproj`.
- Upgrade `NLog.Extensions.Logging` to `5.5.0` in `TournamentManager.csproj`.