### PR TITLE
Move `League` wwwroot static files to embedded resources

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,8 @@
         <Copyright>Copyright 2011-$(CurrentYear) axuno gGmbH</Copyright>
         <RepositoryUrl>https://github.com/axuno/Volleyball-League</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <Version>8.0.0</Version>
-        <FileVersion>8.0.0</FileVersion>
+        <Version>8.2.0</Version>
+        <FileVersion>8.2.0</FileVersion>
         <AssemblyVersion>8.0.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>

--- a/League.Tests/EmbeddedResources/EmbeddedResourcesTests.cs
+++ b/League.Tests/EmbeddedResources/EmbeddedResourcesTests.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.FileProviders;
+using NUnit.Framework;
+
+namespace League.Tests.EmbeddedResources
+{
+    [TestFixture]
+    public class EmbeddedLeagueWwwRootResourcesTests
+    {
+        [TestCase("lib/bootstrap/bootstrap.min.css")]
+        [TestCase("lib/bootstrap/bootstrap-all.min.js")]
+        [TestCase("lib/fontawesome/fontawesome.css")]
+        [TestCase("lib/tempus-dominus/tempus-dominus.all.min.js")]
+        public void EmbeddedResourceFileProvider_ReturnsFileInfo_WhenFileExists(string file)
+        {
+            var assembly = typeof(LeagueStartup).Assembly;
+            // Embedded wwwroot files are in "League.wwwroot"
+            var provider = new EmbeddedFileProvider(assembly, "League.wwwroot");
+            
+            var fileInfo = provider.GetFileInfo("lib/bootstrap/bootstrap.min.css");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(fileInfo.Exists, Is.True, $"Expected embedded file {file} was not found.");
+                Assert.That(fileInfo.PhysicalPath, Is.Null, $"Physical file path was {file} instead of null");
+            });
+        }
+    }
+}

--- a/League/League.csproj
+++ b/League/League.csproj
@@ -224,6 +224,11 @@ Localizations for English and German are included. The library is in operation o
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Include="Templates\Email\**\*.tpl" />
+        <!-- Stop automatically copying wwwroot files to the output directory -->
+        <Content Remove="wwwroot\**\*.*" />
+        <!-- All wwwroot files only exist as embedded resource -->
+        <!-- Add FileProvider = new EmbeddedFileProvider(assembly, "League.wwwroot") -->
+        <EmbeddedResource Include="wwwroot\**\*.*" />
     </ItemGroup>
     <ItemGroup>
         <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />

--- a/League/LeagueStartup.cs
+++ b/League/LeagueStartup.cs
@@ -1,9 +1,19 @@
 ﻿#region ** Usings **
 
+using System.Diagnostics;
+using System.Reflection;
+using Axuno.BackgroundTask;
+using Axuno.VirtualFileSystem;
 using JSNLog;
+using League.BackgroundTasks;
+using League.Caching;
+using League.ConfigurationPoco;
+using League.Emailing;
 using League.Identity;
 using League.ModelBinders;
+using League.MultiTenancy;
 using League.Routing;
+using League.TextTemplatingModule;
 using MailMergeLib;
 using MailMergeLib.AspNet;
 using MailMergeLib.MessageStore;
@@ -12,24 +22,15 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption;
 using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel;
-
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Net.Http.Headers;
 using SD.LLBLGen.Pro.ORMSupportClasses;
-using System.Diagnostics;
-using Axuno.BackgroundTask;
-using Axuno.VirtualFileSystem;
-using League.BackgroundTasks;
-using League.Caching;
-using League.ConfigurationPoco;
-using League.Emailing;
-using League.MultiTenancy;
 using TournamentManager.DI;
 using TournamentManager.MultiTenancy;
-using League.TextTemplatingModule;
 
 #endregion
 
@@ -677,6 +678,17 @@ public static class LeagueStartup
                 };
             }
         });
+
+        // The EmbeddedFileProvider is used to serve static files from the League Razor Class Library.
+        // Register after UseStaticFiles to give wwwroot files precedence over embedded files.
+        var assembly = Assembly.GetExecutingAssembly();
+        app.UseStaticFiles(new StaticFileOptions
+        {
+            // The embedded files are located in the "League.wwwroot" namespace of the assembly
+            FileProvider = new EmbeddedFileProvider(assembly, "League.wwwroot"),
+            RequestPath = ""
+        });
+
         #endregion
 
         app.UseCookiePolicy();


### PR DESCRIPTION
- Modified `League.csproj` to prevent automatic copying of `wwwroot` files; now included as embedded resources.
- Added `EmbeddedFileProvider` in `Configure` method to serve static files from embedded resources alongside existing static `wwwroot` files.
- Bump version to `v8.2.0`