### PR TITLE
Refactor RoundSelectorComponentModel

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,8 @@
         <Copyright>Copyright 2011-$(CurrentYear) axuno gGmbH</Copyright>
         <RepositoryUrl>https://github.com/axuno/Volleyball-League</RepositoryUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <Version>8.2.0</Version>
-        <FileVersion>8.2.0</FileVersion>
+        <Version>8.2.1</Version>
+        <FileVersion>8.2.1</FileVersion>
         <AssemblyVersion>8.0.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>

--- a/League/Components/RoundSelectorComponentModel.cs
+++ b/League/Components/RoundSelectorComponentModel.cs
@@ -14,10 +14,13 @@ public class RoundSelectorComponentModel
     public IList<RoundEntity> RoundWithTypeList { get; set; } = new List<RoundEntity>();
 
     /// <summary>
-    /// This is the key for a "not specified" round. If this value is null, "not specified" cannot be selected
+    /// If the <see cref="SelectedRoundId"/> is <see langword="null"/> and
+    /// <see cref="EnforceExplicitSelection"/> is <see langword="true"/>,
+    /// the selection dropdown will display &quot;Please select...&quot;,
+    /// until a value from the list is selected.
     /// </summary>
     [BindNever]
-    public long? RoundNotSpecifiedKey { get; set; }
+    public bool EnforceExplicitSelection { get; set; }
 
     /// <summary>
     /// Gets or sets the ID which should be shown as selected.

--- a/League/Controllers/Team.cs
+++ b/League/Controllers/Team.cs
@@ -388,7 +388,7 @@ public class Team : AbstractController
             .FirstOrDefault();
         return new RoundSelectorComponentModel
         {
-            RoundNotSpecifiedKey = null,
+            EnforceExplicitSelection = false,
             SelectedRoundId = tir?.RoundId,
             ShowSelector = await _appDb.MatchRepository.GetMatchCountAsync(
                 new PredicateExpression(

--- a/League/Controllers/TeamApplication.cs
+++ b/League/Controllers/TeamApplication.cs
@@ -593,7 +593,7 @@ public class TeamApplication : AbstractController
 
         return new RoundSelectorComponentModel
         {
-            RoundNotSpecifiedKey = null,
+            EnforceExplicitSelection = true,
             SelectedRoundId = tir?.RoundId,
             ShowSelector = await _appDb.MatchRepository.GetMatchCountAsync(
                 new PredicateExpression(

--- a/League/Views/Shared/Components/RoundSelector/Default.cshtml
+++ b/League/Views/Shared/Components/RoundSelector/Default.cshtml
@@ -12,6 +12,9 @@
         {
             <label asp-for="SelectedRoundId" class="form-label"></label>
             <select asp-for="SelectedRoundId" class="form-select d-block col-7" style="min-width: max-content !important" title="@Localizer["Please select a round"]...">
+                <option value="" selected="@(Model.SelectedRoundId == null && Model.EnforceExplicitSelection ? "selected" : null)" disabled hidden>
+                    @Localizer["Please select a round"]...
+                </option>
                 @foreach (var rwt in Model.RoundWithTypeList)
                 {
                     if (rwt.Id == Model.SelectedRoundId)
@@ -22,10 +25,6 @@
                     {
                         <option value="@rwt.Id">@rwt.Description&nbsp;&nbsp;(@rwt.RoundType.Description)</option>
                     }
-                }
-                @if (Model.RoundNotSpecifiedKey.HasValue)
-                {
-                    <option value="@Model.RoundNotSpecifiedKey">@Localizer["Not specified"]</option>
                 }
             </select>
         }

--- a/League/Views/TeamApplication/EditTeam.cshtml
+++ b/League/Views/TeamApplication/EditTeam.cshtml
@@ -1,8 +1,6 @@
 ﻿@using League.Components
 @using League.Controllers
-@using League.TagHelpers
 @using Microsoft.AspNetCore.Mvc.Localization
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @using TournamentManager.MultiTenancy
 @using System.Globalization
 @inject IViewLocalizer Localizer
@@ -46,6 +44,8 @@
 {
     <script type="text/javascript" src="~/lib/tempus-dominus/tempus-dominus.all.min.js" asp-append-version="true"></script>
     <script type="text/javascript">
+        document.getElementById('@Html.IdFor(m => m.Round!.SelectedRoundId)').focus();
+
         const locale = '@(CultureInfo.CurrentCulture.ToString())';
         const parentLocale = '@(CultureInfo.CurrentCulture.Parent.TwoLetterISOLanguageName)';
         const hourCycle = '@(CultureInfo.CurrentCulture.DateTimeFormat.ShortTimePattern.Contains("t") ? 12 : 24)';


### PR DESCRIPTION
- `RoundSelectorComponentModel`:
    - Replaced `RoundNotSpecifiedKey` with `EnforceExplicitSelection`
    - Modified `Default.cshtml` to enhance round selection dropdown with a prompt.
    - When `EnforceExplicitSelection` is `true` users are prompted they must select unless a selection is already taken. Without a selection an error for Required Field will occur.
    - For editing a team, `EnforceExplicitSelection` is `false`. The current value is shown and can be changed.
- Updated `GetRoundSelectorComponentModel` methods in `Team.cs` and `TeamApplication.cs` to reflect changes.
- Added script to set the initial focus to `SelectedRoundId` in `EditTeam.cshtml`.

![image](https://github.com/user-attachments/assets/16011eca-d22a-417d-ab4a-f746304ee8a7)
---
![image](https://github.com/user-attachments/assets/f7fa7517-b125-485b-92d0-dfdf49d6d0c2)

Resolves #234 