### PR TITLE
Refactor `Tenant` configuration

### DIFF
--- a/Axuno.BackgroundTask.Test/BackgroundQueueServiceTests.cs
+++ b/Axuno.BackgroundTask.Test/BackgroundQueueServiceTests.cs
@@ -94,7 +94,7 @@ public class BackgroundQueueServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(itemCounter, Is.EqualTo(expected));
-            Assert.That(typeof(AmbiguousImplementationException), Is.EqualTo(ExceptionFromBackgroundQueue?.GetType()));
+            Assert.That(ExceptionFromBackgroundQueue?.GetType(), Is.EqualTo(typeof(AmbiguousImplementationException)));
         });
     }
 

--- a/Axuno.BackgroundTask.Test/ConcurrentBackgroundQueueServiceTests.cs
+++ b/Axuno.BackgroundTask.Test/ConcurrentBackgroundQueueServiceTests.cs
@@ -94,7 +94,7 @@ public class ConcurrentBackgroundQueueServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(itemCounter, Is.EqualTo(expected));
-            Assert.That(typeof(AmbiguousImplementationException), Is.EqualTo(ExceptionFromBackgroundQueue?.GetType()));
+            Assert.That(ExceptionFromBackgroundQueue?.GetType(), Is.EqualTo(typeof(AmbiguousImplementationException)));
         });
     }
         

--- a/League.Demo/Configuration/Tenant.Default.Development.config
+++ b/League.Demo/Configuration/Tenant.Default.Development.config
@@ -5,7 +5,7 @@
     <!-- The tenant GUID. -->
     <Guid>bf2e2412-c610-4521-ae15-7bda286e4480</Guid>
     <!-- May only be true for a single tenant in a tenant store. -->
-    <IsDefault>True</IsDefault>
+    <IsDefault>true</IsDefault>
     <SiteContext>
         <!-- The position of the tenant within tenant lists (e.g. navigation). -->
         <Position>0</Position>
@@ -18,45 +18,15 @@
         <!-- The session name used for the tenant. -->
         <SessionName>.League</SessionName>
         <!-- If true, the site will not be shown in the navigation menu. -->
-        <HideInMenu>True</HideInMenu>
-        <!-- Email contact details. -->
-        <Email>
-            <!-- "From" mailbox address for the contact form -->
-            <ContactFrom>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Volleyball-Liga</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>league@volleyball-liga.de</Address>
-            </ContactFrom>
-            <!-- "To" mailbox address for the contact form -->
-            <ContactTo>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Volleyball-Liga</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>league@volleyball-liga.de</Address>
-            </ContactTo>
-            <!-- General "To" mailbox address for emails generated programmatically -->
-            <GeneralTo>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Volleyball-Liga</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>league@volleyball-liga.de</Address>
-            </GeneralTo>
-            <!-- General "From" mailbox address for emails generated programmatically -->
-            <GeneralFrom>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Volleyball-Liga</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>league@volleyball-liga.de</Address>
-            </GeneralFrom>
-            <!-- General "BCC" mailbox address for emails generated programmatically -->
-            <GeneralBcc>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Volleyball-Liga</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>league@volleyball-liga.de</Address>
-            </GeneralBcc>
-        </Email>
+        <HideInMenu>true</HideInMenu>
+        <!-- Recipients for generated emails. -->
+        <MailAddresses>
+            <MailAddress Kind="ContactFrom" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
+            <MailAddress Kind="ContactTo" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
+            <MailAddress Kind="GeneralFrom" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
+            <MailAddress Kind="GeneralTo" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
+            <MailAddress Kind="GeneralBcc" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
+        </MailAddresses>
         <!-- Notifications sent before and after matches. -->
         <MatchNotifications>
             <!-- Number of days before the next match will be announced. 0 for none, negative number days. -->
@@ -77,7 +47,7 @@
         <HomepageUrl>https://volleyball-liga.de/</HomepageUrl>
         <Bank>
             <!-- If true, bank details are part of the confirmation email when registering a team. -->
-            <ShowBankDetailsInConfirmationEmail>True</ShowBankDetailsInConfirmationEmail>
+            <ShowBankDetailsInConfirmationEmail>true</ShowBankDetailsInConfirmationEmail>
             <!-- The name of the payment recipient, usually the organization name. -->
             <Recipient>axuno - Testorganization</Recipient>
             <!-- The name of the bank where a payment is directed. -->
@@ -105,10 +75,12 @@
     <TournamentContext>
         <!-- The ID of the tournament which will be used for new teams' applications -->
         <ApplicationTournamentId>0</ApplicationTournamentId>
-        <!-- True, if teams' applications are allowed, otherwise false -->
-        <ApplicationAllowed>True</ApplicationAllowed>
-        <!-- The deadline for new teams' applications -->
-        <ApplicationDeadline>01/01/2021 00:00:00</ApplicationDeadline>
+        <!-- The UTC date from which teams' applications are allowed. -->
+        <!-- Format: 'yyyy-MM-dd HH:mm:ss' or 'MM/dd/yyyy HH:mm:ss' -->
+        <ApplicationStart>10/23/2020 00:00:00</ApplicationStart>
+        <!-- The UTC deadline for new teams' applications. -->
+        <!-- Format: 'yyyy-MM-dd HH:mm:ss' or 'MM/dd/yyyy HH:mm:ss' -->
+        <ApplicationEnd>01/01/2021 00:00:00</ApplicationEnd>
         <!-- The ID of the tournament which will be used for to display maps -->
         <MapTournamentId>0</MapTournamentId>
         <!-- The ID of the tournament which will be used to display team data -->
@@ -121,23 +93,23 @@
         <FixtureRuleSet>
             <!-- The time when matches start and end normally (e.g. from 18:00 - 21:00 h) -->
             <RegularMatchStartTime>
-                <!-- Earliest start time for a match -->
+                <!-- Earliest start time for a match (in local time) -->
                 <MinDayTime>18:00:00</MinDayTime>
-                <!-- Latest start time for a match -->
+                <!-- Latest start time for a match (in local time) -->
                 <MaxDayTime>21:00:00</MaxDayTime>
             </RegularMatchStartTime>
             <!-- The duration which is used to generate fixtures and to determine periods where a venue is occupied -->
             <PlannedDurationOfMatch>02:00:00</PlannedDurationOfMatch>
             <!-- If set to true, when editing a fixture the match time must be set -->
-            <PlannedMatchDateTimeMustBeSet>True</PlannedMatchDateTimeMustBeSet>
+            <PlannedMatchDateTimeMustBeSet>true</PlannedMatchDateTimeMustBeSet>
             <!-- If set to true, the planned match time must no include any dates found in ExcludeMatchDate table entries -->
-            <CheckForExcludedMatchDateTime>True</CheckForExcludedMatchDateTime>
+            <CheckForExcludedMatchDateTime>true</CheckForExcludedMatchDateTime>
             <!-- If set to true, the planned match time must stay within the current leg date boundaries. If false, the planned time must stay with in any leg date boundaries. -->
-            <PlannedMatchTimeMustStayInCurrentLegBoundaries>False</PlannedMatchTimeMustStayInCurrentLegBoundaries>
+            <PlannedMatchTimeMustStayInCurrentLegBoundaries>false</PlannedMatchTimeMustStayInCurrentLegBoundaries>
             <!-- If set to true, when editing a fixture the venue must be set -->
-            <PlannedVenueMustBeSet>True</PlannedVenueMustBeSet>
+            <PlannedVenueMustBeSet>true</PlannedVenueMustBeSet>
             <!-- If true, when checking whether teams already have a match at a certain moment, only the date will be used (i.e. only 1 match per calendar date) -->
-            <UseOnlyDatePartForTeamFreeBusyTimes>True</UseOnlyDatePartForTeamFreeBusyTimes>
+            <UseOnlyDatePartForTeamFreeBusyTimes>true</UseOnlyDatePartForTeamFreeBusyTimes>
         </FixtureRuleSet>
         <!-- The max. number of days after RealStart where results may be changed. Negative value means 'unlimited' -->
         <MaxDaysForResultCorrection>-1</MaxDaysForResultCorrection>
@@ -146,9 +118,9 @@
             <!-- Rules for the HomeMatchTime of a team -->
             <HomeMatchTime>
                 <!-- If true, HomeMatchTime will be shown on team forms. If false, IsEditable, DaysOfWeekRange and ErrorIfNotInDaysOfWeekRange are irrelevant. -->
-                <IsEditable>True</IsEditable>
+                <IsEditable>true</IsEditable>
                 <!-- If true, the HomeMatchTime must be set, i.e. cannot be null/unspecified -->
-                <MustBeSet>True</MustBeSet>
+                <MustBeSet>true</MustBeSet>
                 <!-- Allowed days of a week -->
                 <DaysOfWeekRange>
                     <DayOfWeek>Monday</DayOfWeek>
@@ -160,19 +132,19 @@
                     <DayOfWeek>Sunday</DayOfWeek>
                 </DaysOfWeekRange>
                 <!-- If true, entries not in 'DaysOfWeekRange' are errors (else: warning) -->
-                <ErrorIfNotInDaysOfWeekRange>False</ErrorIfNotInDaysOfWeekRange>
+                <ErrorIfNotInDaysOfWeekRange>false</ErrorIfNotInDaysOfWeekRange>
             </HomeMatchTime>
             <!-- Rules for the HomeVenue of a team. -->
             <HomeVenue>
                 <!-- If true, the HomeVenue must be set, i.e. cannot be null/unspecified. -->
                 <!-- If false, when auto-creating fixtures the team will only have away-matches (i.e. is always the guest team). -->
-                <MustBeSet>True</MustBeSet>
+                <MustBeSet>true</MustBeSet>
             </HomeVenue>
         </TeamRuleSet>
         <!-- Rules for referee master data -->
         <RefereeRuleSet>
-	        <!-- Rules for organizing referees -->
-	        <RefereeType>None</RefereeType>
+            <!-- Rule for organizing referees -->
+            <RefereeType>None</RefereeType>
         </RefereeRuleSet>
     </TournamentContext>
 </TenantContext>

--- a/League.Demo/Configuration/Tenant.Default.Production.config
+++ b/League.Demo/Configuration/Tenant.Default.Production.config
@@ -5,7 +5,7 @@
     <!-- The tenant GUID. -->
     <Guid>bf2e2412-c610-4521-ae15-7bda286e4480</Guid>
     <!-- May only be true for a single tenant in a tenant store. -->
-    <IsDefault>True</IsDefault>
+    <IsDefault>true</IsDefault>
     <SiteContext>
         <!-- The position of the tenant within tenant lists (e.g. navigation). -->
         <Position>0</Position>
@@ -18,44 +18,15 @@
         <!-- The session name used for the tenant. -->
         <SessionName>.League</SessionName>
         <!-- If true, the site will not be shown in the navigation menu. -->
-        <HideInMenu>True</HideInMenu>
-        <!-- Email contact details. -->
-        <Email>
-            <ContactFrom>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Volleyball-Liga</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>league@volleyball-liga.de</Address>
-            </ContactFrom>
-            <!-- "To" mailbox address for the contact form -->
-            <ContactTo>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Volleyball-Liga</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>league@volleyball-liga.de</Address>
-            </ContactTo>
-            <!-- General "To" mailbox address for emails generated programmatically -->
-            <GeneralTo>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Volleyball-Liga</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>league@volleyball-liga.de</Address>
-            </GeneralTo>
-            <!-- General "From" mailbox address for emails generated programmatically -->
-            <GeneralFrom>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Volleyball-Liga</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>league@volleyball-liga.de</Address>
-            </GeneralFrom>
-            <!-- General "BCC" mailbox address for emails generated programmatically -->
-            <GeneralBcc>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Volleyball-Liga</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>league@volleyball-liga.de</Address>
-            </GeneralBcc>
-        </Email>
+        <HideInMenu>true</HideInMenu>
+        <!-- Recipients for generated emails. -->
+        <MailAddresses>
+            <MailAddress Kind="ContactFrom" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
+            <MailAddress Kind="ContactTo" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
+            <MailAddress Kind="GeneralFrom" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
+            <MailAddress Kind="GeneralTo" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
+            <MailAddress Kind="GeneralBcc" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
+        </MailAddresses>
         <!-- Notifications sent before and after matches. -->
         <MatchNotifications>
             <!-- Number of days before the next match will be announced. 0 for none, negative number days. -->
@@ -76,7 +47,7 @@
         <HomepageUrl>https://volleyball-liga.de/</HomepageUrl>
         <Bank>
             <!-- If true, bank details are part of the confirmation email when registering a team. -->
-            <ShowBankDetailsInConfirmationEmail>True</ShowBankDetailsInConfirmationEmail>
+            <ShowBankDetailsInConfirmationEmail>true</ShowBankDetailsInConfirmationEmail>
             <!-- The name of the payment recipient, usually the organization name. -->
             <Recipient>axuno - Testorganization</Recipient>
             <!-- The name of the bank where a payment is directed. -->
@@ -104,10 +75,12 @@
     <TournamentContext>
         <!-- The ID of the tournament which will be used for new teams' applications -->
         <ApplicationTournamentId>0</ApplicationTournamentId>
-        <!-- True, if teams' applications are allowed, otherwise false -->
-        <ApplicationAllowed>True</ApplicationAllowed>
-        <!-- The deadline for new teams' applications -->
-        <ApplicationDeadline>01/01/2021 00:00:00</ApplicationDeadline>
+        <!-- The UTC date from which teams' applications are allowed. -->
+        <!-- Format: 'yyyy-MM-dd HH:mm:ss' or 'MM/dd/yyyy HH:mm:ss' -->
+        <ApplicationStart>10/23/2020 00:00:00</ApplicationStart>
+        <!-- The UTC deadline for new teams' applications. -->
+        <!-- Format: 'yyyy-MM-dd HH:mm:ss' or 'MM/dd/yyyy HH:mm:ss' -->
+        <ApplicationEnd>01/01/2021 00:00:00</ApplicationEnd>
         <!-- The ID of the tournament which will be used for to display maps -->
         <MapTournamentId>0</MapTournamentId>
         <!-- The ID of the tournament which will be used to display team data -->
@@ -120,23 +93,23 @@
         <FixtureRuleSet>
             <!-- The time when matches start and end normally (e.g. from 18:00 - 21:00 h) -->
             <RegularMatchStartTime>
-                <!-- Earliest start time for a match -->
+                <!-- Earliest start time for a match (in local time) -->
                 <MinDayTime>18:00:00</MinDayTime>
-                <!-- Latest start time for a match -->
+                <!-- Latest start time for a match (in local time) -->
                 <MaxDayTime>21:00:00</MaxDayTime>
             </RegularMatchStartTime>
             <!-- The duration which is used to generate fixtures and to determine periods where a venue is occupied -->
             <PlannedDurationOfMatch>02:00:00</PlannedDurationOfMatch>
             <!-- If set to true, when editing a fixture the match time must be set -->
-            <PlannedMatchDateTimeMustBeSet>True</PlannedMatchDateTimeMustBeSet>
+            <PlannedMatchDateTimeMustBeSet>true</PlannedMatchDateTimeMustBeSet>
             <!-- If set to true, the planned match time must no include any dates found in ExcludeMatchDate table entries -->
-            <CheckForExcludedMatchDateTime>True</CheckForExcludedMatchDateTime>
+            <CheckForExcludedMatchDateTime>true</CheckForExcludedMatchDateTime>
             <!-- If set to true, the planned match time must stay within the current leg date boundaries. If false, the planned time must stay with in any leg date boundaries. -->
-            <PlannedMatchTimeMustStayInCurrentLegBoundaries>False</PlannedMatchTimeMustStayInCurrentLegBoundaries>
+            <PlannedMatchTimeMustStayInCurrentLegBoundaries>false</PlannedMatchTimeMustStayInCurrentLegBoundaries>
             <!-- If set to true, when editing a fixture the venue must be set -->
-            <PlannedVenueMustBeSet>True</PlannedVenueMustBeSet>
+            <PlannedVenueMustBeSet>true</PlannedVenueMustBeSet>
             <!-- If true, when checking whether teams already have a match at a certain moment, only the date will be used (i.e. only 1 match per calendar date) -->
-            <UseOnlyDatePartForTeamFreeBusyTimes>True</UseOnlyDatePartForTeamFreeBusyTimes>
+            <UseOnlyDatePartForTeamFreeBusyTimes>true</UseOnlyDatePartForTeamFreeBusyTimes>
         </FixtureRuleSet>
         <!-- The max. number of days after RealStart where results may be changed. Negative value means 'unlimited' -->
         <MaxDaysForResultCorrection>-1</MaxDaysForResultCorrection>
@@ -145,9 +118,9 @@
             <!-- Rules for the HomeMatchTime of a team -->
             <HomeMatchTime>
                 <!-- If true, HomeMatchTime will be shown on team forms. If false, IsEditable, DaysOfWeekRange and ErrorIfNotInDaysOfWeekRange are irrelevant. -->
-                <IsEditable>True</IsEditable>
+                <IsEditable>true</IsEditable>
                 <!-- If true, the HomeMatchTime must be set, i.e. cannot be null/unspecified -->
-                <MustBeSet>True</MustBeSet>
+                <MustBeSet>true</MustBeSet>
                 <!-- Allowed days of a week -->
                 <DaysOfWeekRange>
                     <DayOfWeek>Monday</DayOfWeek>
@@ -159,19 +132,19 @@
                     <DayOfWeek>Sunday</DayOfWeek>
                 </DaysOfWeekRange>
                 <!-- If true, entries not in 'DaysOfWeekRange' are errors (else: warning) -->
-                <ErrorIfNotInDaysOfWeekRange>False</ErrorIfNotInDaysOfWeekRange>
+                <ErrorIfNotInDaysOfWeekRange>false</ErrorIfNotInDaysOfWeekRange>
             </HomeMatchTime>
             <!-- Rules for the HomeVenue of a team. -->
             <HomeVenue>
                 <!-- If true, the HomeVenue must be set, i.e. cannot be null/unspecified. -->
                 <!-- If false, when auto-creating fixtures the team will only have away-matches (i.e. is always the guest team). -->
-                <MustBeSet>True</MustBeSet>
+                <MustBeSet>true</MustBeSet>
             </HomeVenue>
         </TeamRuleSet>
         <!-- Rules for referee master data -->
         <RefereeRuleSet>
-	        <!-- Rules for organizing referees -->
-	        <RefereeType>None</RefereeType>
+            <!-- Rule for organizing referees -->
+            <RefereeType>None</RefereeType>
         </RefereeRuleSet>
     </TournamentContext>
 </TenantContext>

--- a/League.Demo/Configuration/Tenant.OtherOrg.Development.config
+++ b/League.Demo/Configuration/Tenant.OtherOrg.Development.config
@@ -5,7 +5,7 @@
     <!-- The tenant GUID. -->
     <Guid>bf2e2412-c610-4521-ae13-7bda286e4480</Guid>
     <!-- May only be true for a single tenant in a tenant store. -->
-    <IsDefault>False</IsDefault>
+    <IsDefault>false</IsDefault>
     <SiteContext>
         <!-- The position of the tenant within tenant lists (e.g. navigation). -->
         <Position>2</Position>
@@ -18,45 +18,15 @@
         <!-- The session name used for the tenant. -->
         <SessionName>.LeagueOther</SessionName>
         <!-- If true, the site will not be shown in the navigation menu. -->
-        <HideInMenu>False</HideInMenu>
-        <!-- Email contact details. -->
-        <Email>
-            <!-- "From" mailbox address for the contact form -->
-            <ContactFrom>
-                <!-- The display name of a recipient. -->
-                <DisplayName>OtherOrganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </ContactFrom>
-            <!-- "To" mailbox address for the contact form -->
-            <ContactTo>
-                <!-- The display name of a recipient. -->
-                <DisplayName>OtherOrganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </ContactTo>
-            <!-- General "To" mailbox address for emails generated programmatically -->
-            <GeneralTo>
-                <!-- The display name of a recipient. -->
-                <DisplayName>OtherOrganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </GeneralTo>
-            <!-- General "From" mailbox address for emails generated programmatically -->
-            <GeneralFrom>
-                <!-- The display name of a recipient. -->
-                <DisplayName>OtherOrganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </GeneralFrom>
-            <!-- General "BCC" mailbox address for emails generated programmatically -->
-            <GeneralBcc>
-                <!-- The display name of a recipient. -->
-                <DisplayName>OtherOrganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </GeneralBcc>
-        </Email>
+        <HideInMenu>false</HideInMenu>
+        <!-- Recipients for generated emails. -->
+        <MailAddresses>
+            <MailAddress Kind="ContactFrom" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
+            <MailAddress Kind="ContactTo" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
+            <MailAddress Kind="GeneralFrom" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
+            <MailAddress Kind="GeneralTo" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
+            <MailAddress Kind="GeneralBcc" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
+        </MailAddresses>
         <!-- Notifications sent before and after matches. -->
         <MatchNotifications>
             <!-- Number of days before the next match will be announced. 0 for none, negative number days. -->
@@ -77,7 +47,7 @@
         <HomepageUrl>https://volleyball-liga.de/otherorg</HomepageUrl>
         <Bank>
             <!-- If true, bank details are part of the confirmation email when registering a team. -->
-            <ShowBankDetailsInConfirmationEmail>True</ShowBankDetailsInConfirmationEmail>
+            <ShowBankDetailsInConfirmationEmail>true</ShowBankDetailsInConfirmationEmail>
             <!-- The name of the payment recipient, usually the organization name. -->
             <Recipient>axuno - Other Organization</Recipient>
             <!-- The name of the bank where a payment is directed. -->
@@ -105,10 +75,12 @@
     <TournamentContext>
         <!-- The ID of the tournament which will be used for new teams' applications -->
         <ApplicationTournamentId>2</ApplicationTournamentId>
-        <!-- True, if teams' applications are allowed, otherwise false -->
-        <ApplicationAllowed>False</ApplicationAllowed>
-        <!-- The deadline for new teams' applications -->
-        <ApplicationDeadline>04/05/2018 00:00:00</ApplicationDeadline>
+        <!-- The UTC date from which teams' applications are allowed. -->
+        <!-- Format: 'yyyy-MM-dd HH:mm:ss' or 'MM/dd/yyyy HH:mm:ss' -->
+        <ApplicationStart>01/25/2018 00:00:00</ApplicationStart>
+        <!-- The UTC deadline for new teams' applications. -->
+        <!-- Format: 'yyyy-MM-dd HH:mm:ss' or 'MM/dd/yyyy HH:mm:ss' -->
+        <ApplicationEnd>04/05/2018 00:00:00</ApplicationEnd>
         <!-- The ID of the tournament which will be used for to display maps -->
         <MapTournamentId>2</MapTournamentId>
         <!-- The ID of the tournament which will be used to display team data -->
@@ -121,23 +93,23 @@
         <FixtureRuleSet>
             <!-- The time when matches start and end normally (e.g. from 18:00 - 21:00 h) -->
             <RegularMatchStartTime>
-                <!-- Earliest start time for a match -->
+                <!-- Earliest start time for a match (in local time) -->
                 <MinDayTime>18:00:00</MinDayTime>
-                <!-- Latest start time for a match -->
+                <!-- Latest start time for a match (in local time) -->
                 <MaxDayTime>21:00:00</MaxDayTime>
             </RegularMatchStartTime>
             <!-- The duration which is used to generate fixtures and to determine periods where a venue is occupied -->
             <PlannedDurationOfMatch>02:00:00</PlannedDurationOfMatch>
             <!-- If set to true, when editing a fixture the match time must be set -->
-            <PlannedMatchDateTimeMustBeSet>True</PlannedMatchDateTimeMustBeSet>
+            <PlannedMatchDateTimeMustBeSet>true</PlannedMatchDateTimeMustBeSet>
             <!-- If set to true, the planned match time must no include any dates found in ExcludeMatchDate table entries -->
-            <CheckForExcludedMatchDateTime>True</CheckForExcludedMatchDateTime>
+            <CheckForExcludedMatchDateTime>true</CheckForExcludedMatchDateTime>
             <!-- If set to true, the planned match time must stay within the current leg date boundaries. If false, the planned time must stay with in any leg date boundaries. -->
-            <PlannedMatchTimeMustStayInCurrentLegBoundaries>False</PlannedMatchTimeMustStayInCurrentLegBoundaries>
+            <PlannedMatchTimeMustStayInCurrentLegBoundaries>false</PlannedMatchTimeMustStayInCurrentLegBoundaries>
             <!-- If set to true, when editing a fixture the venue must be set -->
-            <PlannedVenueMustBeSet>True</PlannedVenueMustBeSet>
+            <PlannedVenueMustBeSet>true</PlannedVenueMustBeSet>
             <!-- If true, when checking whether teams already have a match at a certain moment, only the date will be used (i.e. only 1 match per calendar date) -->
-            <UseOnlyDatePartForTeamFreeBusyTimes>True</UseOnlyDatePartForTeamFreeBusyTimes>
+            <UseOnlyDatePartForTeamFreeBusyTimes>true</UseOnlyDatePartForTeamFreeBusyTimes>
         </FixtureRuleSet>
         <!-- The max. number of days after RealStart where results may be changed. Negative value means 'unlimited' -->
         <MaxDaysForResultCorrection>-1</MaxDaysForResultCorrection>
@@ -146,9 +118,9 @@
             <!-- Rules for the HomeMatchTime of a team -->
             <HomeMatchTime>
                 <!-- If true, HomeMatchTime will be shown on team forms. If false, IsEditable, DaysOfWeekRange and ErrorIfNotInDaysOfWeekRange are irrelevant. -->
-                <IsEditable>True</IsEditable>
+                <IsEditable>true</IsEditable>
                 <!-- If true, the HomeMatchTime must be set, i.e. cannot be null/unspecified -->
-                <MustBeSet>True</MustBeSet>
+                <MustBeSet>true</MustBeSet>
                 <!-- Allowed days of a week -->
                 <DaysOfWeekRange>
                     <DayOfWeek>Monday</DayOfWeek>
@@ -160,19 +132,19 @@
                     <DayOfWeek>Sunday</DayOfWeek>
                 </DaysOfWeekRange>
                 <!-- If true, entries not in 'DaysOfWeekRange' are errors (else: warning) -->
-                <ErrorIfNotInDaysOfWeekRange>False</ErrorIfNotInDaysOfWeekRange>
+                <ErrorIfNotInDaysOfWeekRange>false</ErrorIfNotInDaysOfWeekRange>
             </HomeMatchTime>
             <!-- Rules for the HomeVenue of a team. -->
             <HomeVenue>
                 <!-- If true, the HomeVenue must be set, i.e. cannot be null/unspecified. -->
                 <!-- If false, when auto-creating fixtures the team will only have away-matches (i.e. is always the guest team). -->
-                <MustBeSet>True</MustBeSet>
+                <MustBeSet>true</MustBeSet>
             </HomeVenue>
         </TeamRuleSet>
         <!-- Rules for referee master data -->
         <RefereeRuleSet>
-	        <!-- Rules for organizing referees -->
-	        <RefereeType>Home</RefereeType>
+            <!-- Rule for organizing referees -->
+            <RefereeType>Home</RefereeType>
         </RefereeRuleSet>
     </TournamentContext>
 </TenantContext>

--- a/League.Demo/Configuration/Tenant.OtherOrg.Production.config
+++ b/League.Demo/Configuration/Tenant.OtherOrg.Production.config
@@ -5,7 +5,7 @@
     <!-- The tenant GUID. -->
     <Guid>bf2e2412-c610-4521-ae13-7bda286e4480</Guid>
     <!-- May only be true for a single tenant in a tenant store. -->
-    <IsDefault>False</IsDefault>
+    <IsDefault>false</IsDefault>
     <SiteContext>
         <!-- The position of the tenant within tenant lists (e.g. navigation). -->
         <Position>2</Position>
@@ -18,44 +18,15 @@
         <!-- The session name used for the tenant. -->
         <SessionName>.LeagueOther</SessionName>
         <!-- If true, the site will not be shown in the navigation menu. -->
-        <HideInMenu>False</HideInMenu>
-        <!-- Email contact details. -->
-        <Email>
-            <ContactFrom>
-                <!-- The display name of a recipient. -->
-                <DisplayName>OtherOrganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </ContactFrom>
-            <!-- "To" mailbox address for the contact form -->
-            <ContactTo>
-                <!-- The display name of a recipient. -->
-                <DisplayName>OtherOrganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </ContactTo>
-            <!-- General "To" mailbox address for emails generated programmatically -->
-            <GeneralTo>
-                <!-- The display name of a recipient. -->
-                <DisplayName>OtherOrganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </GeneralTo>
-            <!-- General "From" mailbox address for emails generated programmatically -->
-            <GeneralFrom>
-                <!-- The display name of a recipient. -->
-                <DisplayName>OtherOrganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </GeneralFrom>
-            <!-- General "BCC" mailbox address for emails generated programmatically -->
-            <GeneralBcc>
-                <!-- The display name of a recipient. -->
-                <DisplayName>OtherOrganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </GeneralBcc>
-        </Email>
+        <HideInMenu>false</HideInMenu>
+        <!-- Recipients for generated emails. -->
+        <MailAddresses>
+            <MailAddress Kind="ContactFrom" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
+            <MailAddress Kind="ContactTo" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
+            <MailAddress Kind="GeneralFrom" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
+            <MailAddress Kind="GeneralTo" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
+            <MailAddress Kind="GeneralBcc" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
+        </MailAddresses>
         <!-- Notifications sent before and after matches. -->
         <MatchNotifications>
             <!-- Number of days before the next match will be announced. 0 for none, negative number days. -->
@@ -76,7 +47,7 @@
         <HomepageUrl>https://volleyball-liga.de/otherorg</HomepageUrl>
         <Bank>
             <!-- If true, bank details are part of the confirmation email when registering a team. -->
-            <ShowBankDetailsInConfirmationEmail>True</ShowBankDetailsInConfirmationEmail>
+            <ShowBankDetailsInConfirmationEmail>true</ShowBankDetailsInConfirmationEmail>
             <!-- The name of the payment recipient, usually the organization name. -->
             <Recipient>axuno - Test Organization</Recipient>
             <!-- The name of the bank where a payment is directed. -->
@@ -104,10 +75,12 @@
     <TournamentContext>
         <!-- The ID of the tournament which will be used for new teams' applications -->
         <ApplicationTournamentId>2</ApplicationTournamentId>
-        <!-- True, if teams' applications are allowed, otherwise false -->
-        <ApplicationAllowed>False</ApplicationAllowed>
-        <!-- The deadline for new teams' applications -->
-        <ApplicationDeadline>04/05/2018 00:00:00</ApplicationDeadline>
+        <!-- The UTC date from which teams' applications are allowed. -->
+        <!-- Format: 'yyyy-MM-dd HH:mm:ss' or 'MM/dd/yyyy HH:mm:ss' -->
+        <ApplicationStart>01/25/2018 00:00:00</ApplicationStart>
+        <!-- The UTC deadline for new teams' applications. -->
+        <!-- Format: 'yyyy-MM-dd HH:mm:ss' or 'MM/dd/yyyy HH:mm:ss' -->
+        <ApplicationEnd>04/05/2099 00:00:00</ApplicationEnd>
         <!-- The ID of the tournament which will be used for to display maps -->
         <MapTournamentId>2</MapTournamentId>
         <!-- The ID of the tournament which will be used to display team data -->
@@ -120,23 +93,23 @@
         <FixtureRuleSet>
             <!-- The time when matches start and end normally (e.g. from 18:00 - 21:00 h) -->
             <RegularMatchStartTime>
-                <!-- Earliest start time for a match -->
+                <!-- Earliest start time for a match (in local time) -->
                 <MinDayTime>18:00:00</MinDayTime>
-                <!-- Latest start time for a match -->
+                <!-- Latest start time for a match (in local time) -->
                 <MaxDayTime>21:00:00</MaxDayTime>
             </RegularMatchStartTime>
             <!-- The duration which is used to generate fixtures and to determine periods where a venue is occupied -->
             <PlannedDurationOfMatch>02:00:00</PlannedDurationOfMatch>
             <!-- If set to true, when editing a fixture the match time must be set -->
-            <PlannedMatchDateTimeMustBeSet>True</PlannedMatchDateTimeMustBeSet>
+            <PlannedMatchDateTimeMustBeSet>true</PlannedMatchDateTimeMustBeSet>
             <!-- If set to true, the planned match time must no include any dates found in ExcludeMatchDate table entries -->
-            <CheckForExcludedMatchDateTime>True</CheckForExcludedMatchDateTime>
+            <CheckForExcludedMatchDateTime>true</CheckForExcludedMatchDateTime>
             <!-- If set to true, the planned match time must stay within the current leg date boundaries. If false, the planned time must stay with in any leg date boundaries. -->
-            <PlannedMatchTimeMustStayInCurrentLegBoundaries>False</PlannedMatchTimeMustStayInCurrentLegBoundaries>
+            <PlannedMatchTimeMustStayInCurrentLegBoundaries>false</PlannedMatchTimeMustStayInCurrentLegBoundaries>
             <!-- If set to true, when editing a fixture the venue must be set -->
-            <PlannedVenueMustBeSet>True</PlannedVenueMustBeSet>
+            <PlannedVenueMustBeSet>true</PlannedVenueMustBeSet>
             <!-- If true, when checking whether teams already have a match at a certain moment, only the date will be used (i.e. only 1 match per calendar date) -->
-            <UseOnlyDatePartForTeamFreeBusyTimes>True</UseOnlyDatePartForTeamFreeBusyTimes>
+            <UseOnlyDatePartForTeamFreeBusyTimes>true</UseOnlyDatePartForTeamFreeBusyTimes>
         </FixtureRuleSet>
         <!-- The max. number of days after RealStart where results may be changed. Negative value means 'unlimited' -->
         <MaxDaysForResultCorrection>-1</MaxDaysForResultCorrection>
@@ -145,9 +118,9 @@
             <!-- Rules for the HomeMatchTime of a team -->
             <HomeMatchTime>
                 <!-- If true, HomeMatchTime will be shown on team forms. If false, IsEditable, DaysOfWeekRange and ErrorIfNotInDaysOfWeekRange are irrelevant. -->
-                <IsEditable>True</IsEditable>
+                <IsEditable>true</IsEditable>
                 <!-- If true, the HomeMatchTime must be set, i.e. cannot be null/unspecified -->
-                <MustBeSet>True</MustBeSet>
+                <MustBeSet>true</MustBeSet>
                 <!-- Allowed days of a week -->
                 <DaysOfWeekRange>
                     <DayOfWeek>Monday</DayOfWeek>
@@ -159,19 +132,19 @@
                     <DayOfWeek>Sunday</DayOfWeek>
                 </DaysOfWeekRange>
                 <!-- If true, entries not in 'DaysOfWeekRange' are errors (else: warning) -->
-                <ErrorIfNotInDaysOfWeekRange>False</ErrorIfNotInDaysOfWeekRange>
+                <ErrorIfNotInDaysOfWeekRange>false</ErrorIfNotInDaysOfWeekRange>
             </HomeMatchTime>
             <!-- Rules for the HomeVenue of a team. -->
             <HomeVenue>
                 <!-- If true, the HomeVenue must be set, i.e. cannot be null/unspecified. -->
                 <!-- If false, when auto-creating fixtures the team will only have away-matches (i.e. is always the guest team). -->
-                <MustBeSet>True</MustBeSet>
+                <MustBeSet>true</MustBeSet>
             </HomeVenue>
         </TeamRuleSet>
         <!-- Rules for referee master data -->
         <RefereeRuleSet>
-	        <!-- Rules for organizing referees -->
-	        <RefereeType>Home</RefereeType>
+            <!-- Rule for organizing referees -->
+            <RefereeType>Home</RefereeType>
         </RefereeRuleSet>
     </TournamentContext>
 </TenantContext>

--- a/League.Demo/Configuration/Tenant.TestOrg.Development.config
+++ b/League.Demo/Configuration/Tenant.TestOrg.Development.config
@@ -5,7 +5,7 @@
     <!-- The tenant GUID. -->
     <Guid>bf2e2412-c610-4521-ae12-7bda286e4480</Guid>
     <!-- May only be true for a single tenant in a tenant store. -->
-    <IsDefault>False</IsDefault>
+    <IsDefault>false</IsDefault>
     <SiteContext>
         <!-- The position of the tenant within tenant lists (e.g. navigation). -->
         <Position>1</Position>
@@ -18,45 +18,15 @@
         <!-- The session name used for the tenant. -->
         <SessionName>.LeagueTest</SessionName>
         <!-- If true, the site will not be shown in the navigation menu. -->
-        <HideInMenu>False</HideInMenu>
-        <!-- Email contact details. -->
-        <Email>
-            <!-- "From" mailbox address for the contact form -->
-            <ContactFrom>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Testorganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </ContactFrom>
-            <!-- "To" mailbox address for the contact form -->
-            <ContactTo>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Testorganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </ContactTo>
-            <!-- General "To" mailbox address for emails generated programmatically -->
-            <GeneralTo>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Testorganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </GeneralTo>
-            <!-- General "From" mailbox address for emails generated programmatically -->
-            <GeneralFrom>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Testorganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </GeneralFrom>
-            <!-- General "BCC" mailbox address for emails generated programmatically -->
-            <GeneralBcc>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Testorganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </GeneralBcc>
-        </Email>
+        <HideInMenu>false</HideInMenu>
+        <!-- Recipients for generated emails. -->
+        <MailAddresses>
+            <MailAddress Kind="ContactFrom" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
+            <MailAddress Kind="ContactTo" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
+            <MailAddress Kind="GeneralFrom" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
+            <MailAddress Kind="GeneralTo" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
+            <MailAddress Kind="GeneralBcc" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
+        </MailAddresses>
         <!-- Notifications sent before and after matches. -->
         <MatchNotifications>
             <!-- Number of days before the next match will be announced. 0 for none, negative number days. -->
@@ -77,7 +47,7 @@
         <HomepageUrl>https://volleyball-liga.de/testorg</HomepageUrl>
         <Bank>
             <!-- If true, bank details are part of the confirmation email when registering a team. -->
-            <ShowBankDetailsInConfirmationEmail>True</ShowBankDetailsInConfirmationEmail>
+            <ShowBankDetailsInConfirmationEmail>true</ShowBankDetailsInConfirmationEmail>
             <!-- The name of the payment recipient, usually the organization name. -->
             <Recipient>axuno - Test Organization</Recipient>
             <!-- The name of the bank where a payment is directed. -->
@@ -105,10 +75,12 @@
     <TournamentContext>
         <!-- The ID of the tournament which will be used for new teams' applications -->
         <ApplicationTournamentId>3</ApplicationTournamentId>
-        <!-- True, if teams' applications are allowed, otherwise false -->
-        <ApplicationAllowed>True</ApplicationAllowed>
-        <!-- The deadline for new teams' applications -->
-        <ApplicationDeadline>04/05/2020 00:00:00</ApplicationDeadline>
+        <!-- The UTC date from which teams' applications are allowed. -->
+        <!-- Format: 'yyyy-MM-dd HH:mm:ss' or 'MM/dd/yyyy HH:mm:ss' -->
+        <ApplicationStart>01/26/2020 00:00:00</ApplicationStart>
+        <!-- The UTC deadline for new teams' applications. -->
+        <!-- Format: 'yyyy-MM-dd HH:mm:ss' or 'MM/dd/yyyy HH:mm:ss' -->
+        <ApplicationEnd>04/05/2099 00:00:00</ApplicationEnd>
         <!-- The ID of the tournament which will be used for to display maps -->
         <MapTournamentId>2</MapTournamentId>
         <!-- The ID of the tournament which will be used to display team data -->
@@ -121,23 +93,23 @@
         <FixtureRuleSet>
             <!-- The time when matches start and end normally (e.g. from 18:00 - 21:00 h) -->
             <RegularMatchStartTime>
-                <!-- Earliest start time for a match -->
+                <!-- Earliest start time for a match (in local time) -->
                 <MinDayTime>18:00:00</MinDayTime>
-                <!-- Latest start time for a match -->
+                <!-- Latest start time for a match (in local time) -->
                 <MaxDayTime>21:00:00</MaxDayTime>
             </RegularMatchStartTime>
             <!-- The duration which is used to generate fixtures and to determine periods where a venue is occupied -->
             <PlannedDurationOfMatch>02:00:00</PlannedDurationOfMatch>
             <!-- If set to true, when editing a fixture the match time must be set -->
-            <PlannedMatchDateTimeMustBeSet>True</PlannedMatchDateTimeMustBeSet>
+            <PlannedMatchDateTimeMustBeSet>true</PlannedMatchDateTimeMustBeSet>
             <!-- If set to true, the planned match time must no include any dates found in ExcludeMatchDate table entries -->
-            <CheckForExcludedMatchDateTime>True</CheckForExcludedMatchDateTime>
+            <CheckForExcludedMatchDateTime>true</CheckForExcludedMatchDateTime>
             <!-- If set to true, the planned match time must stay within the current leg date boundaries. If false, the planned time must stay with in any leg date boundaries. -->
-            <PlannedMatchTimeMustStayInCurrentLegBoundaries>False</PlannedMatchTimeMustStayInCurrentLegBoundaries>
+            <PlannedMatchTimeMustStayInCurrentLegBoundaries>false</PlannedMatchTimeMustStayInCurrentLegBoundaries>
             <!-- If set to true, when editing a fixture the venue must be set -->
-            <PlannedVenueMustBeSet>True</PlannedVenueMustBeSet>
+            <PlannedVenueMustBeSet>true</PlannedVenueMustBeSet>
             <!-- If true, when checking whether teams already have a match at a certain moment, only the date will be used (i.e. only 1 match per calendar date) -->
-            <UseOnlyDatePartForTeamFreeBusyTimes>True</UseOnlyDatePartForTeamFreeBusyTimes>
+            <UseOnlyDatePartForTeamFreeBusyTimes>true</UseOnlyDatePartForTeamFreeBusyTimes>
         </FixtureRuleSet>
         <!-- The max. number of days after RealStart where results may be changed. Negative value means 'unlimited' -->
         <MaxDaysForResultCorrection>-1</MaxDaysForResultCorrection>
@@ -146,9 +118,9 @@
             <!-- Rules for the HomeMatchTime of a team -->
             <HomeMatchTime>
                 <!-- If true, HomeMatchTime will be shown on team forms. If false, IsEditable, DaysOfWeekRange and ErrorIfNotInDaysOfWeekRange are irrelevant. -->
-                <IsEditable>True</IsEditable>
+                <IsEditable>true</IsEditable>
                 <!-- If true, the HomeMatchTime must be set, i.e. cannot be null/unspecified -->
-                <MustBeSet>True</MustBeSet>
+                <MustBeSet>true</MustBeSet>
                 <!-- Allowed days of a week -->
                 <DaysOfWeekRange>
                     <DayOfWeek>Monday</DayOfWeek>
@@ -160,19 +132,19 @@
                     <DayOfWeek>Sunday</DayOfWeek>
                 </DaysOfWeekRange>
                 <!-- If true, entries not in 'DaysOfWeekRange' are errors (else: warning) -->
-                <ErrorIfNotInDaysOfWeekRange>False</ErrorIfNotInDaysOfWeekRange>
+                <ErrorIfNotInDaysOfWeekRange>false</ErrorIfNotInDaysOfWeekRange>
             </HomeMatchTime>
             <!-- Rules for the HomeVenue of a team. -->
             <HomeVenue>
                 <!-- If true, the HomeVenue must be set, i.e. cannot be null/unspecified. -->
                 <!-- If false, when auto-creating fixtures the team will only have away-matches (i.e. is always the guest team). -->
-                <MustBeSet>True</MustBeSet>
+                <MustBeSet>true</MustBeSet>
             </HomeVenue>
         </TeamRuleSet>
         <!-- Rules for referee master data -->
         <RefereeRuleSet>
-	        <!-- Rules for organizing referees -->
-	        <RefereeType>Home</RefereeType>
+            <!-- Rule for organizing referees -->
+            <RefereeType>Home</RefereeType>
         </RefereeRuleSet>
     </TournamentContext>
 </TenantContext>

--- a/League.Demo/Configuration/Tenant.TestOrg.Production.config
+++ b/League.Demo/Configuration/Tenant.TestOrg.Production.config
@@ -5,7 +5,7 @@
     <!-- The tenant GUID. -->
     <Guid>bf2e2412-c610-4521-ae12-7bda286e4480</Guid>
     <!-- May only be true for a single tenant in a tenant store. -->
-    <IsDefault>False</IsDefault>
+    <IsDefault>false</IsDefault>
     <SiteContext>
         <!-- The position of the tenant within tenant lists (e.g. navigation). -->
         <Position>1</Position>
@@ -18,45 +18,15 @@
         <!-- The session name used for the tenant. -->
         <SessionName>.LeagueTest</SessionName>
         <!-- If true, the site will not be shown in the navigation menu. -->
-        <HideInMenu>False</HideInMenu>
-        <!-- Email contact details. -->
-        <Email>
-            <!-- "From" mailbox address for the contact form -->
-            <ContactFrom>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Testorganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </ContactFrom>
-            <!-- "To" mailbox address for the contact form -->
-            <ContactTo>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Testorganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </ContactTo>
-            <!-- General "To" mailbox address for emails generated programmatically -->
-            <GeneralTo>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Testorganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </GeneralTo>
-            <!-- General "From" mailbox address for emails generated programmatically -->
-            <GeneralFrom>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Testorganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </GeneralFrom>
-            <!-- General "BCC" mailbox address for emails generated programmatically -->
-            <GeneralBcc>
-                <!-- The display name of a recipient. -->
-                <DisplayName>Testorganization</DisplayName>
-                <!-- The email address of a recipient. -->
-                <Address>testorg@volleyball-liga.de</Address>
-            </GeneralBcc>
-        </Email>
+        <HideInMenu>false</HideInMenu>
+        <!-- Recipients for generated emails. -->
+        <MailAddresses>
+            <MailAddress Kind="ContactFrom" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
+            <MailAddress Kind="ContactTo" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
+            <MailAddress Kind="GeneralFrom" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
+            <MailAddress Kind="GeneralTo" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
+            <MailAddress Kind="GeneralBcc" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
+        </MailAddresses>
         <!-- Notifications sent before and after matches. -->
         <MatchNotifications>
             <!-- Number of days before the next match will be announced. 0 for none, negative number days. -->
@@ -77,7 +47,7 @@
         <HomepageUrl>https://volleyball-liga.de/testorg</HomepageUrl>
         <Bank>
             <!-- If true, bank details are part of the confirmation email when registering a team. -->
-            <ShowBankDetailsInConfirmationEmail>True</ShowBankDetailsInConfirmationEmail>
+            <ShowBankDetailsInConfirmationEmail>true</ShowBankDetailsInConfirmationEmail>
             <!-- The name of the payment recipient, usually the organization name. -->
             <Recipient>axuno - Test Organization</Recipient>
             <!-- The name of the bank where a payment is directed. -->
@@ -105,10 +75,12 @@
     <TournamentContext>
         <!-- The ID of the tournament which will be used for new teams' applications -->
         <ApplicationTournamentId>3</ApplicationTournamentId>
-        <!-- True, if teams' applications are allowed, otherwise false -->
-        <ApplicationAllowed>True</ApplicationAllowed>
-        <!-- The deadline for new teams' applications -->
-        <ApplicationDeadline>04/05/2020 00:00:00</ApplicationDeadline>
+        <!-- The UTC date from which teams' applications are allowed. -->
+        <!-- Format: 'yyyy-MM-dd HH:mm:ss' or 'MM/dd/yyyy HH:mm:ss' -->
+        <ApplicationStart>01/26/2020 00:00:00</ApplicationStart>
+        <!-- The UTC deadline for new teams' applications. -->
+        <!-- Format: 'yyyy-MM-dd HH:mm:ss' or 'MM/dd/yyyy HH:mm:ss' -->
+        <ApplicationEnd>04/05/2020 00:00:00</ApplicationEnd>
         <!-- The ID of the tournament which will be used for to display maps -->
         <MapTournamentId>2</MapTournamentId>
         <!-- The ID of the tournament which will be used to display team data -->
@@ -121,23 +93,23 @@
         <FixtureRuleSet>
             <!-- The time when matches start and end normally (e.g. from 18:00 - 21:00 h) -->
             <RegularMatchStartTime>
-                <!-- Earliest start time for a match -->
+                <!-- Earliest start time for a match (in local time) -->
                 <MinDayTime>18:00:00</MinDayTime>
-                <!-- Latest start time for a match -->
+                <!-- Latest start time for a match (in local time) -->
                 <MaxDayTime>21:00:00</MaxDayTime>
             </RegularMatchStartTime>
             <!-- The duration which is used to generate fixtures and to determine periods where a venue is occupied -->
             <PlannedDurationOfMatch>02:00:00</PlannedDurationOfMatch>
             <!-- If set to true, when editing a fixture the match time must be set -->
-            <PlannedMatchDateTimeMustBeSet>True</PlannedMatchDateTimeMustBeSet>
+            <PlannedMatchDateTimeMustBeSet>true</PlannedMatchDateTimeMustBeSet>
             <!-- If set to true, the planned match time must no include any dates found in ExcludeMatchDate table entries -->
-            <CheckForExcludedMatchDateTime>True</CheckForExcludedMatchDateTime>
+            <CheckForExcludedMatchDateTime>true</CheckForExcludedMatchDateTime>
             <!-- If set to true, the planned match time must stay within the current leg date boundaries. If false, the planned time must stay with in any leg date boundaries. -->
-            <PlannedMatchTimeMustStayInCurrentLegBoundaries>False</PlannedMatchTimeMustStayInCurrentLegBoundaries>
+            <PlannedMatchTimeMustStayInCurrentLegBoundaries>false</PlannedMatchTimeMustStayInCurrentLegBoundaries>
             <!-- If set to true, when editing a fixture the venue must be set -->
-            <PlannedVenueMustBeSet>True</PlannedVenueMustBeSet>
+            <PlannedVenueMustBeSet>true</PlannedVenueMustBeSet>
             <!-- If true, when checking whether teams already have a match at a certain moment, only the date will be used (i.e. only 1 match per calendar date) -->
-            <UseOnlyDatePartForTeamFreeBusyTimes>True</UseOnlyDatePartForTeamFreeBusyTimes>
+            <UseOnlyDatePartForTeamFreeBusyTimes>true</UseOnlyDatePartForTeamFreeBusyTimes>
         </FixtureRuleSet>
         <!-- The max. number of days after RealStart where results may be changed. Negative value means 'unlimited' -->
         <MaxDaysForResultCorrection>-1</MaxDaysForResultCorrection>
@@ -146,9 +118,9 @@
             <!-- Rules for the HomeMatchTime of a team -->
             <HomeMatchTime>
                 <!-- If true, HomeMatchTime will be shown on team forms. If false, IsEditable, DaysOfWeekRange and ErrorIfNotInDaysOfWeekRange are irrelevant. -->
-                <IsEditable>True</IsEditable>
+                <IsEditable>true</IsEditable>
                 <!-- If true, the HomeMatchTime must be set, i.e. cannot be null/unspecified -->
-                <MustBeSet>True</MustBeSet>
+                <MustBeSet>true</MustBeSet>
                 <!-- Allowed days of a week -->
                 <DaysOfWeekRange>
                     <DayOfWeek>Monday</DayOfWeek>
@@ -160,19 +132,19 @@
                     <DayOfWeek>Sunday</DayOfWeek>
                 </DaysOfWeekRange>
                 <!-- If true, entries not in 'DaysOfWeekRange' are errors (else: warning) -->
-                <ErrorIfNotInDaysOfWeekRange>False</ErrorIfNotInDaysOfWeekRange>
+                <ErrorIfNotInDaysOfWeekRange>false</ErrorIfNotInDaysOfWeekRange>
             </HomeMatchTime>
             <!-- Rules for the HomeVenue of a team. -->
             <HomeVenue>
                 <!-- If true, the HomeVenue must be set, i.e. cannot be null/unspecified. -->
                 <!-- If false, when auto-creating fixtures the team will only have away-matches (i.e. is always the guest team). -->
-                <MustBeSet>True</MustBeSet>
+                <MustBeSet>true</MustBeSet>
             </HomeVenue>
         </TeamRuleSet>
-		<!-- Rules for referee master data -->
-		<RefereeRuleSet>
-			<!-- Rules for organizing referees -->
-			<RefereeType>Home</RefereeType>
-		</RefereeRuleSet>
+        <!-- Rules for referee master data -->
+        <RefereeRuleSet>
+            <!-- Rule for organizing referees -->
+            <RefereeType>Home</RefereeType>
+        </RefereeRuleSet>
     </TournamentContext>
 </TenantContext>

--- a/League.Tests/TenantContent/TenantContentProviderTests.cs
+++ b/League.Tests/TenantContent/TenantContentProviderTests.cs
@@ -154,7 +154,7 @@ public class TenantContentProviderTests
         {
         }
 
-        public IReadOnlyDictionary<string, ITenantContext> GetTenants()
+        public new IReadOnlyDictionary<string, ITenantContext> GetTenants()
         {
             var tenants = new Dictionary<string, ITenantContext>
             {

--- a/League/ControllerAttributes/TeamApplicationAllowedAttribute.cs
+++ b/League/ControllerAttributes/TeamApplicationAllowedAttribute.cs
@@ -11,7 +11,7 @@ public class TeamApplicationAllowedAttribute : ActionFilterAttribute
     {
         if (context.HttpContext.RequestServices.GetService(typeof(ITenantContext)) is
                 ITenantContext tenantContext &&
-            (!tenantContext.TournamentContext.ApplicationAllowed
+            (!(DateTime.UtcNow >= tenantContext.TournamentContext.ApplicationStart && DateTime.UtcNow < tenantContext.TournamentContext.ApplicationEnd)
              && ((context.RouteData.Values["controller"]?.ToString() ?? string.Empty)
                  .Equals(nameof(League.Controllers.TeamApplication),
                      StringComparison.OrdinalIgnoreCase) &&

--- a/League/Emailing/Creators/AnnounceNextMatchCreator.cs
+++ b/League/Emailing/Creators/AnnounceNextMatchCreator.cs
@@ -70,7 +70,8 @@ public class AnnounceNextMatchCreator : IMailMessageCreator
             {
                 var mailMergeMessage = mailMergeService.CreateStandardMessage();
                 mailMergeMessage.EnableFormatter = false;
-                mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.From, tenantContext.SiteContext.Email.GeneralFrom.DisplayName, tenantContext.SiteContext.Email.GeneralFrom.Address));
+                mailMergeMessage.MailMergeAddresses
+                    .Add(MailKind.GeneralFrom, tenantContext);
 
                 foreach (var tur in recipients)
                 {
@@ -93,10 +94,7 @@ public class AnnounceNextMatchCreator : IMailMessageCreator
                 }
                     
                 // Send registration info also to league administration
-                mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.Bcc,
-                    tenantContext.SiteContext.Email.GeneralBcc.DisplayName,
-                    tenantContext.SiteContext.Email.GeneralBcc.Address));
-
+                mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralBcc, tenantContext);
                 mailMergeMessage.PlainText = plainTextContent;
 
                 yield return mailMergeMessage;

--- a/League/Emailing/Creators/ChangeFixtureCreator.cs
+++ b/League/Emailing/Creators/ChangeFixtureCreator.cs
@@ -68,7 +68,7 @@ public class ChangeFixtureCreator : IMailMessageCreator
         {
             var mailMergeMessage = mailMergeService.CreateStandardMessage();
             mailMergeMessage.EnableFormatter = false;
-            mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.From, tenantContext.SiteContext.Email.GeneralFrom.DisplayName, tenantContext.SiteContext.Email.GeneralFrom.Address));
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralFrom, tenantContext);
 
             foreach (var tur in recipients)
             {
@@ -91,10 +91,7 @@ public class ChangeFixtureCreator : IMailMessageCreator
             }
                 
             // Send registration info also to league administration
-            mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.Bcc,
-                tenantContext.SiteContext.Email.GeneralBcc.DisplayName,
-                tenantContext.SiteContext.Email.GeneralBcc.Address));
-                
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralBcc, tenantContext);
             mailMergeMessage.PlainText = plainTextContent;
 
             yield return mailMergeMessage;

--- a/League/Emailing/Creators/ChangePrimaryUserEmailCreator.cs
+++ b/League/Emailing/Creators/ChangePrimaryUserEmailCreator.cs
@@ -53,7 +53,7 @@ public class ChangePrimaryUserEmailCreator : IMailMessageCreator
             mailMergeMessage.EnableFormatter = false;
             mailMergeMessage.Subject = localizer["Please confirm your new primary email"].Value;
                 
-            mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.From, tenantContext.SiteContext.Email.GeneralFrom.DisplayName, tenantContext.SiteContext.Email.GeneralFrom.Address));
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralFrom, tenantContext);
             mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.To, Parameters.NewEmail));
 
             mailMergeMessage.PlainText = await renderer.RenderAsync(TemplateName.ConfirmNewPrimaryEmailTxt, model,
@@ -76,7 +76,7 @@ public class ChangePrimaryUserEmailCreator : IMailMessageCreator
             mailMergeMessage.EnableFormatter = false;
             mailMergeMessage.Subject = localizer["Your primary email is about to be changed"].Value;
                 
-            mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.From, tenantContext.SiteContext.Email.GeneralFrom.DisplayName, tenantContext.SiteContext.Email.GeneralFrom.Address));
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralFrom, tenantContext);
             mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.To, Parameters.Email));
 
             mailMergeMessage.PlainText = await renderer.RenderAsync(TemplateName.NotifyCurrentPrimaryEmailTxt, model,

--- a/League/Emailing/Creators/ChangeUserAccountCreator.cs
+++ b/League/Emailing/Creators/ChangeUserAccountCreator.cs
@@ -51,7 +51,7 @@ public class ChangeUserAccountCreator : IMailMessageCreator
             mailMergeMessage.EnableFormatter = false;
             mailMergeMessage.Subject = Parameters.Subject; // already localized
                 
-            mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.From, tenantContext.SiteContext.Email.GeneralFrom.DisplayName, tenantContext.SiteContext.Email.GeneralFrom.Address));
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralFrom, tenantContext);
             mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.To, Parameters.Email));
 
             mailMergeMessage.PlainText = await renderer.RenderAsync(Parameters.TemplateNameTxt, model,

--- a/League/Emailing/Creators/ConfirmTeamApplicationCreator.cs
+++ b/League/Emailing/Creators/ConfirmTeamApplicationCreator.cs
@@ -70,8 +70,8 @@ public class ConfirmTeamApplicationCreator : IMailMessageCreator
             mailMergeMessage.Subject = model.IsNewApplication
                 ? localizer["Confirmation of the team registration"].Value
                 : localizer["Update of team registration"].Value;
-                
-            mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.From, tenantContext.SiteContext.Email.GeneralFrom.DisplayName, tenantContext.SiteContext.Email.GeneralFrom.Address));
+
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralFrom, tenantContext);
             mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.To,
                 $"{tur.CompleteName}, Team '{tur.TeamName}'", tur.Email));
             if (!string.IsNullOrEmpty(tur.Email2))
@@ -83,9 +83,7 @@ public class ConfirmTeamApplicationCreator : IMailMessageCreator
             if (model.IsRegisteringUser)
             {
                 // Send registration info also to league administration
-                mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.Bcc,
-                    tenantContext.SiteContext.Email.GeneralBcc.DisplayName,
-                    tenantContext.SiteContext.Email.GeneralBcc.Address));
+                mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralBcc, tenantContext);
             }
 
             mailMergeMessage.PlainText = await renderer.RenderAsync(Templates.Email.TemplateName.ConfirmTeamApplicationTxt, model,

--- a/League/Emailing/Creators/ContactFormCreator.cs
+++ b/League/Emailing/Creators/ContactFormCreator.cs
@@ -42,9 +42,9 @@ public class ContactFormCreator : IMailMessageCreator
             var mailMergeMessage = mailMergeService.CreateStandardMessage();
             mailMergeMessage.EnableFormatter = false;
             mailMergeMessage.Subject = model.Form.Subject!; // user-generated, cannot localize!
-                
-            mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.From, tenantContext.SiteContext.Email.ContactFrom.Address));
-            mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.To, tenantContext.SiteContext.Email.ContactTo.Address));
+
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.ContactFrom, tenantContext);
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralTo, tenantContext);
             mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.ReplyTo, model.Form.Email));
 
             mailMergeMessage.PlainText = await renderer.RenderAsync(Templates.Email.TemplateName.ContactFormTxt, model,

--- a/League/Emailing/Creators/RemindMatchResultCreator.cs
+++ b/League/Emailing/Creators/RemindMatchResultCreator.cs
@@ -67,7 +67,7 @@ public class RemindMatchResult : IMailMessageCreator
             {
                 var mailMergeMessage = mailMergeService.CreateStandardMessage();
                 mailMergeMessage.EnableFormatter = false;
-                mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.From, tenantContext.SiteContext.Email.GeneralFrom.DisplayName, tenantContext.SiteContext.Email.GeneralFrom.Address));
+                mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralFrom, tenantContext);
 
                 foreach (var tur in recipients)
                 {
@@ -90,10 +90,7 @@ public class RemindMatchResult : IMailMessageCreator
                 }
                     
                 // Send registration info also to league administration
-                mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.Bcc,
-                    tenantContext.SiteContext.Email.GeneralBcc.DisplayName,
-                    tenantContext.SiteContext.Email.GeneralBcc.Address));
-
+                mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralBcc, tenantContext);
                 mailMergeMessage.PlainText = plainTextContent;
 
                 yield return mailMergeMessage;

--- a/League/Emailing/Creators/ResultEnteredCreator.cs
+++ b/League/Emailing/Creators/ResultEnteredCreator.cs
@@ -75,7 +75,7 @@ public class ResultEnteredCreator : IMailMessageCreator
         {
             var mailMergeMessage = mailMergeService.CreateStandardMessage();
             mailMergeMessage.EnableFormatter = false;
-            mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.From, tenantContext.SiteContext.Email.GeneralFrom.DisplayName, tenantContext.SiteContext.Email.GeneralFrom.Address));
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralFrom, tenantContext);
 
             foreach (var tur in recipients)
             {
@@ -100,9 +100,7 @@ public class ResultEnteredCreator : IMailMessageCreator
             }
                 
             // Send info also to league administration
-            mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.Bcc,
-                tenantContext.SiteContext.Email.GeneralBcc.DisplayName,
-                tenantContext.SiteContext.Email.GeneralBcc.Address));
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralBcc, tenantContext);
                 
             mailMergeMessage.PlainText = plainTextContent;
 

--- a/League/Emailing/Creators/UrgeMatchResultCreator.cs
+++ b/League/Emailing/Creators/UrgeMatchResultCreator.cs
@@ -67,7 +67,7 @@ public class UrgeMatchResultCreator : IMailMessageCreator
             {
                 var mailMergeMessage = mailMergeService.CreateStandardMessage();
                 mailMergeMessage.EnableFormatter = false;
-                mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.From, tenantContext.SiteContext.Email.GeneralFrom.DisplayName, tenantContext.SiteContext.Email.GeneralFrom.Address));
+                mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralFrom, tenantContext);
 
                 foreach (var tur in recipients)
                 {
@@ -90,9 +90,7 @@ public class UrgeMatchResultCreator : IMailMessageCreator
                 }
                     
                 // Send registration info also to league administration
-                mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.Bcc,
-                    tenantContext.SiteContext.Email.GeneralBcc.DisplayName,
-                    tenantContext.SiteContext.Email.GeneralBcc.Address));
+                mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralBcc, tenantContext);
 
                 mailMergeMessage.PlainText = plainTextContent;
 

--- a/League/Emailing/MailMergeAddressCollectionExtensions.cs
+++ b/League/Emailing/MailMergeAddressCollectionExtensions.cs
@@ -1,0 +1,47 @@
+﻿using MailMergeLib;
+using TournamentManager.MultiTenancy;
+
+namespace League.Emailing;
+internal static class MailMergeAddressCollectionExtensions
+{
+    public static void Add(this MailMergeAddressCollection addresses, MailKind mailKind, ITenantContext tenantContext)
+    {
+        if (mailKind == MailKind.None) return;
+
+        var siteContext = tenantContext.SiteContext;
+
+        // Map MailKind to MailMergeAddressType
+        var addressType = mailKind switch
+        {
+            MailKind.GeneralFrom or MailKind.ContactFrom => MailAddressType.From,
+            MailKind.GeneralTo or MailKind.ContactTo => MailAddressType.To,
+            MailKind.GeneralBcc => MailAddressType.Bcc,
+            _ => MailAddressType.To // Default fallback
+        };
+
+        if (addressType == MailAddressType.From)
+        {
+            var mailAddress = siteContext.MailAddresses.FirstOrDefault(a => a.Kind == mailKind);
+            if (mailAddress == null) return;
+
+            addresses.Add(new MailMergeAddress(
+                addressType,
+                displayName: mailAddress.DisplayName,
+                address: mailAddress.Address
+            ));
+            return;
+        }
+
+        var mailAddresses = siteContext.MailAddresses
+            .Where(a => a.Kind == mailKind);
+
+        foreach (var mailAddress in mailAddresses)
+        {
+            addresses.Add(new MailMergeAddress(
+                addressType,
+                displayName: mailAddress.DisplayName,
+                address: mailAddress.Address
+            ));
+        }
+    }
+}

--- a/League/Views/TeamApplication/List.cshtml
+++ b/League/Views/TeamApplication/List.cshtml
@@ -16,10 +16,10 @@
         <h2 id="@tableDescriptionId" class="h2">@ViewData["Title"]</h2>
         <hr class="mb-4" />
         <partial name="@nameof(League.Views.ViewNames.TeamApplication._TeamApplicationMessagesPartial)" />
-        @if (TenantContext.TournamentContext.ApplicationAllowed)
+        @if (DateTime.UtcNow >= TenantContext.TournamentContext.ApplicationStart && DateTime.UtcNow < TenantContext.TournamentContext.ApplicationEnd)
         {
             <a asp-controller="@nameof(League.Controllers.TeamApplication)" asp-action="@nameof(League.Controllers.TeamApplication.Start)" asp-route-tenant="@tenantUrlSegment" class="btn btn-primary mb-2">@Localizer["Register team now"]</a>
-            <span class="ms-5 text-success">@(Localizer["Closing date"]): @Model.TimeZoneConverter.ToZonedTime(TenantContext.TournamentContext.ApplicationDeadline)?.DateTimeOffset.DateTime.ToShortDateString()</span>
+            <span class="ms-5 text-success">@(Localizer["Closing date"]): @Model.TimeZoneConverter.ToZonedTime(TenantContext.TournamentContext.ApplicationEnd)?.DateTimeOffset.DateTime.ToShortDateString()</span>
         }
         else
         {

--- a/TournamentManager/TournamentManager/MultiTenancy/AbstractTenantStore.cs
+++ b/TournamentManager/TournamentManager/MultiTenancy/AbstractTenantStore.cs
@@ -40,7 +40,7 @@ public class AbstractTenantStore<T> : ITenantStore<T> where T: class, ITenantCon
     /// <returns>Returns the <see cref="ITenantContext"/> configuration for the tenant with the specified <paramref name="identifier"/> or <see langword="null"/> if it could not be found.</returns>
     public virtual ITenantContext? GetTenantByIdentifier(string identifier)
     {
-        return Tenants.TryGetValue(identifier, out var tenant) ? tenant : null;
+        return Tenants.GetValueOrDefault(identifier);
     }
 
     /// <summary>

--- a/TournamentManager/TournamentManager/MultiTenancy/ISiteContext.cs
+++ b/TournamentManager/TournamentManager/MultiTenancy/ISiteContext.cs
@@ -1,4 +1,6 @@
-﻿namespace TournamentManager.MultiTenancy;
+﻿using System.Collections.ObjectModel;
+
+namespace TournamentManager.MultiTenancy;
 
 public interface ISiteContext
 {
@@ -41,8 +43,8 @@ public interface ISiteContext
     /// <summary>
     /// Email contact details for an organization.
     /// </summary>
-    Email Email { get; set; }
-        
+    Collection<MailAddress> MailAddresses { get; set; }
+
     /// <summary>
     /// Notifications sent before and after matches.
     /// </summary>

--- a/TournamentManager/TournamentManager/MultiTenancy/ITournamentContext.cs
+++ b/TournamentManager/TournamentManager/MultiTenancy/ITournamentContext.cs
@@ -1,7 +1,7 @@
 ﻿namespace TournamentManager.MultiTenancy;
 
 /// <summary>
-/// The class contains all configuration data for a tournament.
+/// Contains all configuration data for a tournament.
 /// </summary>
 public interface ITournamentContext
 {
@@ -16,14 +16,14 @@ public interface ITournamentContext
     long ApplicationTournamentId { get; set; }
 
     /// <summary>
-    /// Return true, if teams' applications are allowed, otherwise false.
+    /// The date from which teams' applications are allowed.
     /// </summary>
-    bool ApplicationAllowed { get; set; }
+    DateTime ApplicationStart { get; set; }
 
     /// <summary>
     /// The deadline for new teams' applications.
     /// </summary>
-    DateTime ApplicationDeadline { get; set; }
+    DateTime ApplicationEnd { get; set; }
 
     /// <summary>
     /// The ID of the tournament which will be used for to display maps.

--- a/TournamentManager/TournamentManager/MultiTenancy/SiteContext.cs
+++ b/TournamentManager/TournamentManager/MultiTenancy/SiteContext.cs
@@ -1,4 +1,6 @@
-﻿namespace TournamentManager.MultiTenancy;
+﻿using System.Collections.ObjectModel;
+
+namespace TournamentManager.MultiTenancy;
 
 /// <summary>
 /// Provides site-specific data.
@@ -44,11 +46,10 @@ public class SiteContext : ISiteContext
     /// </summary>
     [YAXLib.Attributes.YAXComment("If true, the site will not be shown in the navigation menu.")]
     public bool HideInMenu { get; set; }
-    /// <summary>
-    /// Email contact details.
-    /// </summary>
-    [YAXLib.Attributes.YAXComment("Email contact details.")]
-    public Email Email { get; set; } = new();
+
+    /// <inhertitdoc/>
+    [YAXLib.Attributes.YAXComment("Recipients for generated emails.")]
+    public Collection<MailAddress> MailAddresses { get; set; } = new();
 
     /// <summary>
     /// Notifications sent before and after matches.
@@ -56,56 +57,45 @@ public class SiteContext : ISiteContext
     [YAXLib.Attributes.YAXComment("Notifications sent before and after matches.")]
     public MatchNotifications MatchNotifications { get; set; } = new();
 }
-    
+
 /// <summary>
-/// Email contact details for an organization.
+/// Category of email address.
 /// </summary>
-public class Email
+public enum MailKind
 {
-    /// <summary>
-    /// "From" mailbox address for the contact form
-    /// </summary>
-    [YAXLib.Attributes.YAXComment("\"From\" mailbox address for the contact form\"")]
-    public MailAddress ContactFrom { get; set; } = new();
-    /// <summary>
-    /// "To" mailbox address for the contact form
-    /// </summary>
-    [YAXLib.Attributes.YAXComment("\"To\" mailbox address for the contact form")]
-    public MailAddress ContactTo { get; set; } = new();
-    /// <summary>
-    /// General "To" mailbox address for emails generated programmatically
-    /// </summary>
-    [YAXLib.Attributes.YAXComment("General \"To\" mailbox address for emails generated programmatically")]
-    public MailAddress GeneralTo { get; set; } = new();
-    /// <summary>
-    /// General "From" mailbox address for emails generated programmatically
-    /// </summary>
-    [YAXLib.Attributes.YAXComment("General \"From\" mailbox address for emails generated programmatically")]
-    public MailAddress GeneralFrom { get; set; } = new();
-    /// <summary>
-    /// General "BCC" mailbox address for emails generated programmatically
-    /// </summary>
-    [YAXLib.Attributes.YAXComment("General \"BCC\" mailbox address for emails generated programmatically")]
-    public MailAddress GeneralBcc { get; set; } = new();
+    None,
+    ContactFrom,
+    ContactTo,
+    GeneralFrom,
+    GeneralTo,
+    GeneralBcc
 }
 
 /// <summary>
 /// Email display name and address.
 /// </summary>
+[YAXLib.Attributes.YAXSerializeAs(nameof(MailAddress))]
 public class MailAddress
 {
     /// <summary>
-    /// The display name of a recipient.
+    /// The kind of email address.
     /// </summary>
-    [YAXLib.Attributes.YAXComment("The display name of a recipient.")]
-    public string DisplayName { get; set; } = string.Empty;
+    [YAXLib.Attributes.YAXAttributeForClass]
+    public MailKind Kind { get; set; } = MailKind.None;
 
     /// <summary>
     /// The email address of a recipient.
     /// </summary>
-    [YAXLib.Attributes.YAXComment("The email address of a recipient.")]
+    [YAXLib.Attributes.YAXAttributeForClass]
     public string Address { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The display name of a recipient.
+    /// </summary>
+    [YAXLib.Attributes.YAXAttributeForClass]
+    public string DisplayName { get; set; } = string.Empty;
 }
+
 
 /// <summary>
 /// Notifications sent before and after matches.
@@ -130,3 +120,4 @@ public class MatchNotifications
     [YAXLib.Attributes.YAXComment("Number of days to remind 2nd time for missing match results. 0 for none, positive number of days.")]
     public int DaysForMatchResultReminder2 { get; set; } = 0;
 }
+

--- a/TournamentManager/TournamentManager/MultiTenancy/TenantContext.cs
+++ b/TournamentManager/TournamentManager/MultiTenancy/TenantContext.cs
@@ -81,7 +81,7 @@ public class TenantContext : ITenantContext
     /// </summary>
     [YAXLib.Attributes.YAXDontSerialize]
     public string Filename { get; set; } = string.Empty;
-        
+
     /// <summary>
     /// Provides site-specific data.
     /// </summary>

--- a/TournamentManager/TournamentManager/MultiTenancy/TournamentContext.cs
+++ b/TournamentManager/TournamentManager/MultiTenancy/TournamentContext.cs
@@ -2,85 +2,70 @@
 
 namespace TournamentManager.MultiTenancy;
 
-/// <summary>
-/// The class contains all configuration data for a tournament.
-/// </summary>
+/// <inheritdoc cref="ITournamentContext"/>
 [YAXLib.Attributes.YAXComment("Configuration data for a tournament")]
 public class TournamentContext : ITournamentContext
 {
-    /// <summary>
-    /// Gets or sets the <see cref="ITenant"/> this context refers to.
-    /// </summary>
+    /// <inheritdoc/>
     [YAXLib.Attributes.YAXDontSerialize]
     public ITenant? Tenant { get; set; }
-        
-    /// <summary>
-    /// The ID of the tournament which will be used for new teams' applications.
-    /// </summary>
+
+    /// <inheritdoc/>
     [YAXLib.Attributes.YAXComment("The ID of the tournament which will be used for new teams' applications")]
     public long ApplicationTournamentId { get; set; }
 
-    /// <summary>
-    /// Return true, if teams' applications are allowed, otherwise false.
-    /// </summary>
-    [YAXLib.Attributes.YAXComment("True, if teams' applications are allowed, otherwise false")]
-    public bool ApplicationAllowed { get; set; }
-        
-    /// <summary>
-    /// The deadline for new teams' applications.
-    /// </summary>
-    [YAXLib.Attributes.YAXComment("The deadline for new teams' applications")]
-    public DateTime ApplicationDeadline { get; set; }
+    /// <inheritdoc/>
+    [YAXLib.Attributes.YAXComment(
+        """
+        The UTC date from which teams' applications are allowed.
+        Format: 'yyyy-MM-dd HH:mm:ss' or 'MM/dd/yyyy HH:mm:ss'
+        """)]
+    public DateTime ApplicationStart { get; set; }
 
-    /// <summary>
-    /// The ID of the tournament which will be used for to display maps.
-    /// </summary>
+    /// <inheritdoc/>
+    [YAXLib.Attributes.YAXComment(
+        """
+        The UTC deadline for new teams' applications.
+        Format: 'yyyy-MM-dd HH:mm:ss' or 'MM/dd/yyyy HH:mm:ss'
+        """)]
+    public DateTime ApplicationEnd { get; set; }
+
+    /// <inheritdoc/>
     [YAXLib.Attributes.YAXComment("The ID of the tournament which will be used for to display maps")]
     public long MapTournamentId { get; set; }
-        
-    /// <summary>
-    /// The ID of the tournament which will be used to display team data.
-    /// </summary>
+
+    /// <inheritdoc/>
     [YAXLib.Attributes.YAXComment("The ID of the tournament which will be used to display team data")]
     public long TeamTournamentId { get; set; }
-        
-    /// <summary>
-    /// The ID of the tournament which will be used to display the match plan.
-    /// </summary>
+
+    /// <inheritdoc/>
     [YAXLib.Attributes.YAXComment("The ID of the tournament which will be used to display the match plan")]
     public long MatchPlanTournamentId { get; set; }
-        
-    /// <summary>
-    /// The ID of the tournament which will be used to display match results and tables.
-    /// </summary>
+
+    /// <inheritdoc/>
     [YAXLib.Attributes.YAXComment("The ID of the tournament which will be used to display match results and tables")]
     public long MatchResultTournamentId { get; set; }
 
-    /// <summary>
-    /// A set of rules for creating and editing fixtures.
-    /// </summary>
+    /// <inheritdoc/>
     [YAXLib.Attributes.YAXComment("The rules which apply for creating and editing fixtures")]
     public FixtureRuleSet FixtureRuleSet { get; set; } = new();
 
-    /// <summary>
-    ///	The max. number of days after RealStart where results may be changed. Negative value means 'unlimited'.
-    /// </summary>
+    /// <inheritdoc/>
     [YAXLib.Attributes.YAXComment("The max. number of days after RealStart where results may be changed. Negative value means 'unlimited'")]
     public int MaxDaysForResultCorrection { get; set; }
 
-    /// <summary>
-    /// Rules for team master data
-    /// </summary>
+    /// <inheritdoc/>
     [YAXLib.Attributes.YAXComment("The rules which apply for creating and editing team data")]
     public TeamRules TeamRuleSet { get; set; } = new();
 
-    /// <summary>
-    /// Rules for referee master data.
-    /// </summary>
+    /// <inheritdoc/>
     [YAXLib.Attributes.YAXComment("Rules for referee master data")]
     public RefereeRules RefereeRuleSet { get; set; } = new();
 }
 
+/// <summary>
+/// A set of rules for creating and editing fixtures.
+/// </summary>
 public class FixtureRuleSet
 {
     /// <summary>
@@ -136,14 +121,14 @@ public class FixtureRuleSet
 public class RegularMatchStartTime
 {
     /// <summary>
-    /// Earliest start time for a match.
+    /// Earliest start time for a match (in local time).
     /// </summary>
-    [YAXLib.Attributes.YAXComment("Earliest start time for a match")]
+    [YAXLib.Attributes.YAXComment("Earliest start time for a match (in local time)")]
     public TimeSpan MinDayTime { get; set; } = new(0,18,0,0);
     /// <summary>
-    /// Latest start time for a match.
+    /// Latest start time for a match (in local time).
     /// </summary>
-    [YAXLib.Attributes.YAXComment("Latest start time for a match")]
+    [YAXLib.Attributes.YAXComment("Latest start time for a match (in local time)")]
     public TimeSpan MaxDayTime { get; set; } = new(0, 21,0,0);
 }
 
@@ -220,9 +205,10 @@ public class HomeVenue
     /// If <see langword="true"/>, the <see cref="HomeVenue"/> must be set, i.e. cannot be null/unspecified.
     /// If <see langword="false"/>, when auto-creating fixtures the team will only have away-matches (is always the guest team).
     /// </summary>
-    [YAXLib.Attributes.YAXComment("""
-                                  If true, the HomeVenue must be set, i.e. cannot be null/unspecified.
-                                  If false, when auto-creating fixtures the team will only have away-matches (i.e. is always the guest team).
-                                  """)]
+    [YAXLib.Attributes.YAXComment(
+          """
+          If true, the HomeVenue must be set, i.e. cannot be null/unspecified.
+          If false, when auto-creating fixtures the team will only have away-matches (i.e. is always the guest team).
+          """)]
     public bool MustBeSet { get; set; } = true;
 }


### PR DESCRIPTION
- Email addresses in `SiteContext` are stored in `MailAddresses`. They are used for recepients of automatic emails.
- Updated corresponding sections in `TenantContext.*.config`  configuration files
- `TournamentContext`: Introduced `ApplicationStart` and `ApplicationEnd` fields for application periods.
- Refactored mail merge address handling in based on `MailAddresses`
- Modified `ISiteContext` and `ITournamentContext` interfaces.
- Added `MailMergeAddressCollectionExtensions` for simple mapping of `MailAddresses` to `MailMergeAddresses`
- Updated XML comments and unit tests