### PR TITLE
Refactor `MailKind`

### DIFF
--- a/League.Demo/Configuration/Tenant.Default.Development.config
+++ b/League.Demo/Configuration/Tenant.Default.Development.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <TenantContext>
     <!-- Identifies the tenant. Value is also used for tenant-specific file names. -->
     <Identifier>League</Identifier>
@@ -23,9 +23,9 @@
         <MailAddresses>
             <MailAddress Kind="ContactFrom" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
             <MailAddress Kind="ContactTo" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
-            <MailAddress Kind="GeneralFrom" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
-            <MailAddress Kind="GeneralTo" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
-            <MailAddress Kind="GeneralBcc" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
+            <MailAddress Kind="AutoMailFrom" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
+            <MailAddress Kind="AutoMailTo" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
+            <MailAddress Kind="AutoMailBcc" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
         </MailAddresses>
         <!-- Notifications sent before and after matches. -->
         <MatchNotifications>

--- a/League.Demo/Configuration/Tenant.Default.Production.config
+++ b/League.Demo/Configuration/Tenant.Default.Production.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <TenantContext>
     <!-- Identifies the tenant. Value is also used for tenant-specific file names. -->
     <Identifier>League</Identifier>
@@ -23,9 +23,9 @@
         <MailAddresses>
             <MailAddress Kind="ContactFrom" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
             <MailAddress Kind="ContactTo" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
-            <MailAddress Kind="GeneralFrom" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
-            <MailAddress Kind="GeneralTo" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
-            <MailAddress Kind="GeneralBcc" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
+            <MailAddress Kind="AutoMailFrom" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
+            <MailAddress Kind="AutoMailTo" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
+            <MailAddress Kind="AutoMailBcc" Address="league@volleyball-liga.de" DisplayName="Volleyball-Liga" />
         </MailAddresses>
         <!-- Notifications sent before and after matches. -->
         <MatchNotifications>

--- a/League.Demo/Configuration/Tenant.OtherOrg.Development.config
+++ b/League.Demo/Configuration/Tenant.OtherOrg.Development.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <TenantContext>
     <!-- Identifies the tenant. Value is also used for tenant-specific file names. -->
     <Identifier>OtherOrg</Identifier>
@@ -23,9 +23,9 @@
         <MailAddresses>
             <MailAddress Kind="ContactFrom" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
             <MailAddress Kind="ContactTo" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
-            <MailAddress Kind="GeneralFrom" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
-            <MailAddress Kind="GeneralTo" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
-            <MailAddress Kind="GeneralBcc" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
+            <MailAddress Kind="AutoMailFrom" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
+            <MailAddress Kind="AutoMailTo" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
+            <MailAddress Kind="AutoMailBcc" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
         </MailAddresses>
         <!-- Notifications sent before and after matches. -->
         <MatchNotifications>

--- a/League.Demo/Configuration/Tenant.OtherOrg.Production.config
+++ b/League.Demo/Configuration/Tenant.OtherOrg.Production.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <TenantContext>
     <!-- Identifies the tenant. Value is also used for tenant-specific file names. -->
     <Identifier>OtherOrg</Identifier>
@@ -23,9 +23,9 @@
         <MailAddresses>
             <MailAddress Kind="ContactFrom" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
             <MailAddress Kind="ContactTo" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
-            <MailAddress Kind="GeneralFrom" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
-            <MailAddress Kind="GeneralTo" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
-            <MailAddress Kind="GeneralBcc" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
+            <MailAddress Kind="AutoMailFrom" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
+            <MailAddress Kind="AutoMailTo" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
+            <MailAddress Kind="AutoMailBcc" Address="testorg@volleyball-liga.de" DisplayName="OtherOrganization" />
         </MailAddresses>
         <!-- Notifications sent before and after matches. -->
         <MatchNotifications>

--- a/League.Demo/Configuration/Tenant.TestOrg.Development.config
+++ b/League.Demo/Configuration/Tenant.TestOrg.Development.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <TenantContext>
     <!-- Identifies the tenant. Value is also used for tenant-specific file names. -->
     <Identifier>TestOrg</Identifier>
@@ -23,9 +23,9 @@
         <MailAddresses>
             <MailAddress Kind="ContactFrom" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
             <MailAddress Kind="ContactTo" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
-            <MailAddress Kind="GeneralFrom" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
-            <MailAddress Kind="GeneralTo" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
-            <MailAddress Kind="GeneralBcc" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
+            <MailAddress Kind="AutoMailFrom" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
+            <MailAddress Kind="AutoMailTo" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
+            <MailAddress Kind="AutoMailBcc" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
         </MailAddresses>
         <!-- Notifications sent before and after matches. -->
         <MatchNotifications>

--- a/League.Demo/Configuration/Tenant.TestOrg.Production.config
+++ b/League.Demo/Configuration/Tenant.TestOrg.Production.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <TenantContext>
     <!-- Identifies the tenant. Value is also used for tenant-specific file names. -->
     <Identifier>TestOrg</Identifier>
@@ -23,9 +23,9 @@
         <MailAddresses>
             <MailAddress Kind="ContactFrom" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
             <MailAddress Kind="ContactTo" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
-            <MailAddress Kind="GeneralFrom" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
-            <MailAddress Kind="GeneralTo" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
-            <MailAddress Kind="GeneralBcc" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
+            <MailAddress Kind="AutoMailFrom" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
+            <MailAddress Kind="AutoMailTo" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
+            <MailAddress Kind="AutoMailBcc" Address="testorg@volleyball-liga.de" DisplayName="Testorganization" />
         </MailAddresses>
         <!-- Notifications sent before and after matches. -->
         <MatchNotifications>

--- a/League/Emailing/Creators/AnnounceNextMatchCreator.cs
+++ b/League/Emailing/Creators/AnnounceNextMatchCreator.cs
@@ -71,7 +71,7 @@ public class AnnounceNextMatchCreator : IMailMessageCreator
                 var mailMergeMessage = mailMergeService.CreateStandardMessage();
                 mailMergeMessage.EnableFormatter = false;
                 mailMergeMessage.MailMergeAddresses
-                    .Add(MailKind.GeneralFrom, tenantContext);
+                    .Add(MailKind.AutoMailFrom, tenantContext);
 
                 foreach (var tur in recipients)
                 {
@@ -92,9 +92,9 @@ public class AnnounceNextMatchCreator : IMailMessageCreator
                             $"{tur.CompleteName}", tur.Email2));
                     }
                 }
-                    
-                // Send registration info also to league administration
-                mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralBcc, tenantContext);
+
+                mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailTo, tenantContext);
+                mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailBcc, tenantContext);
                 mailMergeMessage.PlainText = plainTextContent;
 
                 yield return mailMergeMessage;

--- a/League/Emailing/Creators/ChangeFixtureCreator.cs
+++ b/League/Emailing/Creators/ChangeFixtureCreator.cs
@@ -68,7 +68,7 @@ public class ChangeFixtureCreator : IMailMessageCreator
         {
             var mailMergeMessage = mailMergeService.CreateStandardMessage();
             mailMergeMessage.EnableFormatter = false;
-            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralFrom, tenantContext);
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailFrom, tenantContext);
 
             foreach (var tur in recipients)
             {
@@ -89,9 +89,9 @@ public class ChangeFixtureCreator : IMailMessageCreator
                         $"{tur.CompleteName}", tur.Email2));
                 }
             }
-                
-            // Send registration info also to league administration
-            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralBcc, tenantContext);
+
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailTo, tenantContext);
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailBcc, tenantContext);
             mailMergeMessage.PlainText = plainTextContent;
 
             yield return mailMergeMessage;

--- a/League/Emailing/Creators/ChangePrimaryUserEmailCreator.cs
+++ b/League/Emailing/Creators/ChangePrimaryUserEmailCreator.cs
@@ -53,7 +53,7 @@ public class ChangePrimaryUserEmailCreator : IMailMessageCreator
             mailMergeMessage.EnableFormatter = false;
             mailMergeMessage.Subject = localizer["Please confirm your new primary email"].Value;
                 
-            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralFrom, tenantContext);
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailFrom, tenantContext);
             mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.To, Parameters.NewEmail));
 
             mailMergeMessage.PlainText = await renderer.RenderAsync(TemplateName.ConfirmNewPrimaryEmailTxt, model,
@@ -76,7 +76,7 @@ public class ChangePrimaryUserEmailCreator : IMailMessageCreator
             mailMergeMessage.EnableFormatter = false;
             mailMergeMessage.Subject = localizer["Your primary email is about to be changed"].Value;
                 
-            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralFrom, tenantContext);
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailFrom, tenantContext);
             mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.To, Parameters.Email));
 
             mailMergeMessage.PlainText = await renderer.RenderAsync(TemplateName.NotifyCurrentPrimaryEmailTxt, model,

--- a/League/Emailing/Creators/ChangeUserAccountCreator.cs
+++ b/League/Emailing/Creators/ChangeUserAccountCreator.cs
@@ -51,7 +51,7 @@ public class ChangeUserAccountCreator : IMailMessageCreator
             mailMergeMessage.EnableFormatter = false;
             mailMergeMessage.Subject = Parameters.Subject; // already localized
                 
-            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralFrom, tenantContext);
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailFrom, tenantContext);
             mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.To, Parameters.Email));
 
             mailMergeMessage.PlainText = await renderer.RenderAsync(Parameters.TemplateNameTxt, model,

--- a/League/Emailing/Creators/ConfirmTeamApplicationCreator.cs
+++ b/League/Emailing/Creators/ConfirmTeamApplicationCreator.cs
@@ -71,7 +71,7 @@ public class ConfirmTeamApplicationCreator : IMailMessageCreator
                 ? localizer["Confirmation of the team registration"].Value
                 : localizer["Update of team registration"].Value;
 
-            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralFrom, tenantContext);
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailFrom, tenantContext);
             mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.To,
                 $"{tur.CompleteName}, Team '{tur.TeamName}'", tur.Email));
             if (!string.IsNullOrEmpty(tur.Email2))
@@ -82,8 +82,8 @@ public class ConfirmTeamApplicationCreator : IMailMessageCreator
 
             if (model.IsRegisteringUser)
             {
-                // Send registration info also to league administration
-                mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralBcc, tenantContext);
+                mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailTo, tenantContext);
+                mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailBcc, tenantContext);
             }
 
             mailMergeMessage.PlainText = await renderer.RenderAsync(Templates.Email.TemplateName.ConfirmTeamApplicationTxt, model,

--- a/League/Emailing/Creators/ContactFormCreator.cs
+++ b/League/Emailing/Creators/ContactFormCreator.cs
@@ -44,7 +44,7 @@ public class ContactFormCreator : IMailMessageCreator
             mailMergeMessage.Subject = model.Form.Subject!; // user-generated, cannot localize!
 
             mailMergeMessage.MailMergeAddresses.Add(MailKind.ContactFrom, tenantContext);
-            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralTo, tenantContext);
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.ContactTo, tenantContext);
             mailMergeMessage.MailMergeAddresses.Add(new MailMergeAddress(MailAddressType.ReplyTo, model.Form.Email));
 
             mailMergeMessage.PlainText = await renderer.RenderAsync(Templates.Email.TemplateName.ContactFormTxt, model,

--- a/League/Emailing/Creators/RemindMatchResultCreator.cs
+++ b/League/Emailing/Creators/RemindMatchResultCreator.cs
@@ -67,7 +67,7 @@ public class RemindMatchResult : IMailMessageCreator
             {
                 var mailMergeMessage = mailMergeService.CreateStandardMessage();
                 mailMergeMessage.EnableFormatter = false;
-                mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralFrom, tenantContext);
+                mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailFrom, tenantContext);
 
                 foreach (var tur in recipients)
                 {
@@ -88,9 +88,9 @@ public class RemindMatchResult : IMailMessageCreator
                             $"{tur.CompleteName}", tur.Email2));
                     }
                 }
-                    
-                // Send registration info also to league administration
-                mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralBcc, tenantContext);
+
+                mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailTo, tenantContext);
+                mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailBcc, tenantContext);
                 mailMergeMessage.PlainText = plainTextContent;
 
                 yield return mailMergeMessage;

--- a/League/Emailing/Creators/ResultEnteredCreator.cs
+++ b/League/Emailing/Creators/ResultEnteredCreator.cs
@@ -75,7 +75,7 @@ public class ResultEnteredCreator : IMailMessageCreator
         {
             var mailMergeMessage = mailMergeService.CreateStandardMessage();
             mailMergeMessage.EnableFormatter = false;
-            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralFrom, tenantContext);
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailFrom, tenantContext);
 
             foreach (var tur in recipients)
             {
@@ -98,9 +98,9 @@ public class ResultEnteredCreator : IMailMessageCreator
                         $"{tur.CompleteName}", tur.Email2));
                 }
             }
-                
-            // Send info also to league administration
-            mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralBcc, tenantContext);
+
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailTo, tenantContext);
+            mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailBcc, tenantContext);
                 
             mailMergeMessage.PlainText = plainTextContent;
 

--- a/League/Emailing/Creators/UrgeMatchResultCreator.cs
+++ b/League/Emailing/Creators/UrgeMatchResultCreator.cs
@@ -67,7 +67,7 @@ public class UrgeMatchResultCreator : IMailMessageCreator
             {
                 var mailMergeMessage = mailMergeService.CreateStandardMessage();
                 mailMergeMessage.EnableFormatter = false;
-                mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralFrom, tenantContext);
+                mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailFrom, tenantContext);
 
                 foreach (var tur in recipients)
                 {
@@ -88,9 +88,9 @@ public class UrgeMatchResultCreator : IMailMessageCreator
                             $"{tur.CompleteName}", tur.Email2));
                     }
                 }
-                    
-                // Send registration info also to league administration
-                mailMergeMessage.MailMergeAddresses.Add(MailKind.GeneralBcc, tenantContext);
+
+                mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailTo, tenantContext);
+                mailMergeMessage.MailMergeAddresses.Add(MailKind.AutoMailBcc, tenantContext);
 
                 mailMergeMessage.PlainText = plainTextContent;
 

--- a/League/Emailing/MailMergeAddressCollectionExtensions.cs
+++ b/League/Emailing/MailMergeAddressCollectionExtensions.cs
@@ -13,9 +13,9 @@ internal static class MailMergeAddressCollectionExtensions
         // Map MailKind to MailMergeAddressType
         var addressType = mailKind switch
         {
-            MailKind.GeneralFrom or MailKind.ContactFrom => MailAddressType.From,
-            MailKind.GeneralTo or MailKind.ContactTo => MailAddressType.To,
-            MailKind.GeneralBcc => MailAddressType.Bcc,
+            MailKind.AutoMailFrom or MailKind.ContactFrom => MailAddressType.From,
+            MailKind.AutoMailTo or MailKind.ContactTo => MailAddressType.To,
+            MailKind.AutoMailBcc => MailAddressType.Bcc,
             _ => MailAddressType.To // Default fallback
         };
 

--- a/TournamentManager/TournamentManager/MultiTenancy/SiteContext.cs
+++ b/TournamentManager/TournamentManager/MultiTenancy/SiteContext.cs
@@ -66,9 +66,9 @@ public enum MailKind
     None,
     ContactFrom,
     ContactTo,
-    GeneralFrom,
-    GeneralTo,
-    GeneralBcc
+    AutoMailFrom,
+    AutoMailTo,
+    AutoMailBcc
 }
 
 /// <summary>


### PR DESCRIPTION
- Use more self-explaining terms
- Fix: `ContactTo` was not used for the contact form. Now it is.
- Fix: `GeneralTo` was not in use. Now `AutoMailTo` and `AutoMailBcc` `MailAddress`es are always used in the same context.
- Updated existing `Tenant.*.config` filex accordingly

Before:
```cs
public enum MailKind
{
    None,
    ContactFrom,
    ContactTo,
    GeneralFrom,
    GeneralTo,
    GeneralBcc
}
```

Updated:
```cs
public enum MailKind
{
    None,
    ContactFrom,
    ContactTo,
    AutoMailFrom,
    AutoMailTo,
    AutoMailBcc
}
```