### PR TITLE
`Salutation` in Contact form and PersonalDetails form

### DIFF
--- a/League/Views/Contact/Index.cshtml
+++ b/League/Views/Contact/Index.cshtml
@@ -9,9 +9,13 @@
 #pragma warning disable CS8321 // This method is actually used in this view
     List<SelectListItem> GenderList()
     {
-        return new List<SelectListItem> {new() {Value = string.Empty, Text = Localizer["Please choose"].Value}, 
-            new() {Value = "f", Text = Localizer["Mrs."].Value}, 
-            new() {Value = "m", Text = Localizer["Mr."].Value}};
+        return
+        [
+            new() { Value = string.Empty, Text = Localizer["Please choose"].Value, Disabled = true, Selected = true },
+            new() { Value = "f", Text = Localizer["Mrs."].Value },
+            new() { Value = "m", Text = Localizer["Mr."].Value },
+            new() { Value = "u", Text = Localizer["none"].Value }
+        ];
     }
 #pragma warning restore CS8321
 }

--- a/League/Views/Contact/Index.de.resx
+++ b/League/Views/Contact/Index.de.resx
@@ -141,4 +141,7 @@
   <data name="to" xml:space="preserve">
     <value>an</value>
   </data>
+  <data name="none" xml:space="preserve">
+    <value>keine</value>
+  </data>
 </root>

--- a/League/Views/Manage/_EditPersonalDetailsModalPartial.cshtml
+++ b/League/Views/Manage/_EditPersonalDetailsModalPartial.cshtml
@@ -10,9 +10,10 @@
     {
         var genderList = new List<SelectListItem>
         {
-            new SelectListItem { Value = string.Empty, Text = Localizer["Please choose"].Value },
-            new SelectListItem { Value = "f", Text = Localizer["Mrs."].Value },
-            new SelectListItem { Value = "m", Text = Localizer["Mr."].Value }
+            new() { Value = string.Empty, Text = Localizer["Please choose"].Value, Disabled = true, Selected = true },
+            new() { Value = "f", Text = Localizer["Mrs."].Value },
+            new() { Value = "m", Text = Localizer["Mr."].Value },
+            new() { Value = "u", Text = Localizer["none"].Value }
         };
         return genderList;
     }

--- a/League/Views/Manage/_EditPersonalDetailsModalPartial.de.resx
+++ b/League/Views/Manage/_EditPersonalDetailsModalPartial.de.resx
@@ -138,4 +138,7 @@
   <data name="Save" xml:space="preserve">
     <value>Speichern</value>
   </data>
+  <data name="none" xml:space="preserve">
+    <value>keine</value>
+  </data>
 </root>


### PR DESCRIPTION
Changed options for `Salutation` in `Contact` form and `PersonalDetails` forms
to `male` - `female` - `none`