### PR TITLE
Add team manager checks and warnings for missing phone numbers

### DIFF
--- a/League/Controllers/Manage.cs
+++ b/League/Controllers/Manage.cs
@@ -69,11 +69,13 @@ public class Manage : AbstractController
         {
             return Redirect(TenantLink.Action(nameof(Account.SignIn), nameof(Account))!);
         }
-            
+        var claims = await _userManager.GetClaimsAsync(user);
+
         var model = new IndexViewModel(_timeZoneConverter)
         {
             ApplicationUser = user,
             HasPassword = await _userManager.HasPasswordAsync(user),
+            IsTeamManager = claims.Any(c => c.Type.Equals(Constants.ClaimType.ManagesTeam, StringComparison.InvariantCultureIgnoreCase)),
             Logins = await _userManager.GetLoginsAsync(user),
             ManageMessage = TempData.Get<ManageMessage>(nameof(ManageMessage))
         };
@@ -82,7 +84,7 @@ public class Manage : AbstractController
             _regionInfo.TwoLetterISORegionName);
         model.ApplicationUser.PhoneNumber2 = _phoneNumberService.Format(model.ApplicationUser.PhoneNumber2,
             _regionInfo.TwoLetterISORegionName);
-
+        
         return View(model);
     }
 

--- a/League/Models/ManageViewModels/IndexViewModel.cs
+++ b/League/Models/ManageViewModels/IndexViewModel.cs
@@ -13,6 +13,7 @@ public class IndexViewModel
 
     public ApplicationUser? ApplicationUser { get; set; }
     public bool HasPassword { get; set; }
+    public bool IsTeamManager { get; set; }
     public IList<UserLoginInfo> Logins { get; set; } = new List<UserLoginInfo>();
     public ManageMessage? ManageMessage { get; set; }
 }

--- a/League/Views/Manage/Index.cshtml
+++ b/League/Views/Manage/Index.cshtml
@@ -63,7 +63,17 @@
     </ul>
     <ul class="list-inline g-0">
         <li class="list-inline-item col-12 text-success col-md-3">@(Metadata.GetDisplayName<EditPhoneViewModel>(nameof(EditPhoneViewModel.PhoneNumber)))</li>
-        <li class="list-inline-item col-12 col-md-7">@Html.Raw(string.IsNullOrEmpty(Model.ApplicationUser.PhoneNumber) ? Localizer["[Not set]"].Value : Model.ApplicationUser.PhoneNumber)</li>
+        <li class="list-inline-item col-12 col-md-7">
+            @Html.Raw(string.IsNullOrEmpty(Model.ApplicationUser.PhoneNumber) 
+                ? Localizer["[Not set]"].Value 
+                : Model.ApplicationUser.PhoneNumber)
+            @{
+                if (string.IsNullOrEmpty(Model.ApplicationUser.PhoneNumber) && Model.IsTeamManager)
+                {
+                    <span class="text-danger ps-2">⚠ @Localizer["You're a team contact - please add"].Value</span>
+                }
+            }
+        </li>
         <li class="list-inline-item col-12 col-md-auto"><button type="button" site-toggle-modal-ajax site-data-url="@TenantLink.Action(nameof(Manage.EditPhoneNumber), nameof(Manage))" class="btn btn-sm btn-primary">@Localizer["Edit"]</button></li>
     </ul>
     <ul class="list-inline g-0">

--- a/League/Views/Manage/Index.de.resx
+++ b/League/Views/Manage/Index.de.resx
@@ -150,4 +150,7 @@
   <data name="Last update" xml:space="preserve">
     <value>Letzte Änderung</value>
   </data>
+  <data name="You're a team contact - please add" xml:space="preserve">
+    <value>Du bist Teamkontakt - bitte angeben</value>
+  </data>
 </root>

--- a/League/Views/Team/MyTeam.cshtml
+++ b/League/Views/Team/MyTeam.cshtml
@@ -199,6 +199,12 @@
                                                 <a data-bs-toggle="collapse" href="#user-@userInfo.UserId" aria-expanded="false" class="d-inline-block collapsed">
                                                     <i class="fas fa-user"></i><span class="username d-inline-block ms-2 me-2">@userInfo.CompleteNameWithNickName</span>
                                                     <i class="fas fa-chevron-left pull-end text-success"></i>
+                                                    @{
+                                                        if (userInfo.IsManager && string.IsNullOrEmpty(userInfo.PhoneNumber))
+                                                        {
+                                                            <span class="text-danger ps-5">⚠ @Localizer["Missing primary phone number"].Value</span>
+                                                        }
+                                                    }
                                                 </a>
                                             </div>
                                             <div id="user-@userInfo.UserId" class="collapse mb-2 ms-5">

--- a/League/Views/Team/MyTeam.de.resx
+++ b/League/Views/Team/MyTeam.de.resx
@@ -138,6 +138,9 @@
   <data name="Last update" xml:space="preserve">
     <value>Letzte Änderung</value>
   </data>
+  <data name="Missing primary phone number" xml:space="preserve">
+    <value>Primäre Telefonnummer fehlt</value>
+  </data>
   <data name="My Team" xml:space="preserve">
     <value>Mein Team</value>
   </data>


### PR DESCRIPTION
Updated the `Index` method in `Manage.cs` to check user claims for team managers. Introduced `IsTeamManager` property in `IndexViewModel` and updated the view to display warnings for team managers without a primary phone number.

Modified `IndexViewModel.cs` to include the new property. Updated `Index.cshtml` to conditionally render warning messages.

Localized strings added to `Index.de.resx` and `MyTeam.de.resx` for the new warning messages. Similar checks implemented in `MyTeam.cshtml` for managers missing their primary phone number.

Resolves #29 