### PR TITLE
iCalendar Event Creation for Planned Matches using `ical.net 5.0.0`

### DIFF
--- a/League/Controllers/Match.cs
+++ b/League/Controllers/Match.cs
@@ -135,18 +135,11 @@ public class Match : AbstractController
                 DescriptionFooter = "\n" + _tenantContext.OrganizationContext.Name + "\n" + _tenantContext.OrganizationContext.HomepageUrl
             };
             var stream = new MemoryStream();
-            // RFC5545 sect. 3.4.1: iCal default charset is UTF8.
-            // Important: no Byte Order Mark (BOM) for Android, Google, Apple
-            var encoding = new UTF8Encoding(false);
-            matches.ForEach(m =>
-            {
-                // convert to local time
-                m.PlannedStart = _timeZoneConverter.ToZonedTime(m.PlannedStart)?.DateTimeOffset.DateTime;
-                m.PlannedEnd = _timeZoneConverter.ToZonedTime(m.PlannedEnd)?.DateTimeOffset.DateTime;
-            });
-            calendar.CreateEvents(matches).Serialize(stream, encoding); 
-            stream.Seek(0, SeekOrigin.Begin); 
-            return File(stream, $"text/calendar; charset={encoding.HeaderName}", $"Match_{matches[0].PlannedStart?.ToString("yyyy-MM-dd") ?? string.Empty}_{Guid.NewGuid():N}.ics");
+
+            // match date/times have DateTimeKind.Unspecified but are in UTC
+            calendar.CreateEvents(matches, "UTC").Serialize(stream); // stream is UTF8 without BOM by default
+            stream.Seek(0, SeekOrigin.Begin);
+            return File(stream, $"text/calendar; charset={Encoding.UTF8.WebName}", $"Match_{matches[0].PlannedStart?.ToString("yyyy-MM-dd") ?? string.Empty}_{Guid.NewGuid():N}.ics");
         }
         catch (Exception e)
         {
@@ -181,18 +174,11 @@ public class Match : AbstractController
                 DescriptionFooter = "\n" + _tenantContext.OrganizationContext.Name + "\n" + _tenantContext.OrganizationContext.HomepageUrl
             };
             var stream = new MemoryStream();
-            // RFC5545 sect. 3.4.1: iCal default charset is UTF8.
-            // Important: no Byte Order Mark (BOM) for Android, Google, Apple
-            var encoding = new UTF8Encoding(false);
-            matches.ForEach(m =>
-            {
-                // convert to local time
-                m.PlannedStart = _timeZoneConverter.ToZonedTime(m.PlannedStart)?.DateTimeOffset.DateTime;
-                m.PlannedEnd = _timeZoneConverter.ToZonedTime(m.PlannedEnd)?.DateTimeOffset.DateTime;
-            });
-            calendar.CreateEvents(matches).Serialize(stream, encoding);
+
+            // match date/times have DateTimeKind.Unspecified but are in UTC
+            calendar.CreateEvents(matches, "UTC").Serialize(stream); // stream is UTF8 without BOM by default
             stream.Seek(0, SeekOrigin.Begin);
-            return File(stream, $"text/calendar; charset={encoding.HeaderName}", $"Match_{Guid.NewGuid():N}.ics");
+            return File(stream, $"text/calendar; charset={Encoding.UTF8.WebName}", $"Match_{Guid.NewGuid():N}.ics");
         }
         catch (Exception e)
         {

--- a/League/Views/Match/Fixtures.cshtml
+++ b/League/Views/Match/Fixtures.cshtml
@@ -124,7 +124,10 @@
                                                     <a asp-action=@nameof(League.Controllers.Match.EnterResult) asp-controller=@nameof(League.Controllers.Match) asp-route-tenant="@tenantUrlSegment" asp-route-id=@match.Id tabindex="0" class="dropdown-item"
                                                        site-authorize-resource site-resource="@ToMatchEntity(match)"
                                                        site-requirement="@League.Authorization.MatchOperations.EnterResult">@Localizer["Enter match result"]</a>
-                                                    <a asp-action=@nameof(League.Controllers.Match.Calendar) asp-Controller=@nameof(League.Controllers.Match) asp-route-tenant="@tenantUrlSegment" asp-route-id=@match.Id tabindex="0" class="dropdown-item">@Localizer["Save match to calendar"]</a>
+                                                    @if (match is { PlannedStart: not null, PlannedEnd: not null })
+                                                    {
+                                                        <a asp-action=@nameof(League.Controllers.Match.Calendar) asp-Controller=@nameof(League.Controllers.Match) asp-route-tenant="@tenantUrlSegment" asp-route-id=@match.Id tabindex="0" class="dropdown-item">@Localizer["Save match to calendar"]</a>
+                                                    }
                                                 </div>
                                             </div>
                                             <div class="dropdown">
@@ -140,7 +143,10 @@
                                                     <a asp-action=@nameof(League.Controllers.Match.EnterResult) asp-controller=@nameof(League.Controllers.Match) asp-route-tenant="@tenantUrlSegment" asp-route-id=@match.Id tabindex="0" class="dropdown-item"
                                                        site-authorize-resource site-resource="@ToMatchEntity(match)"
                                                        site-requirement="@League.Authorization.MatchOperations.EnterResult">@Localizer["Enter match result"]</a>
-                                                    <a asp-action=@nameof(League.Controllers.Match.Calendar) asp-Controller=@nameof(League.Controllers.Match) asp-route-tenant="@tenantUrlSegment" asp-route-id=@match.Id tabindex="0" class="dropdown-item">@Localizer["Save match to calendar"]</a>
+                                                    @if (match is { PlannedStart: not null, PlannedEnd: not null })
+                                                    {
+                                                        <a asp-action=@nameof(League.Controllers.Match.Calendar) asp-Controller=@nameof(League.Controllers.Match) asp-route-tenant="@tenantUrlSegment" asp-route-id=@match.Id tabindex="0" class="dropdown-item">@Localizer["Save match to calendar"]</a>
+                                                    }
                                                 </div>
                                             </div>
                                         </td>

--- a/TournamentManager/TournamentManager.Tests/Importers/ExcludeDates/InternetCalendarImporterTests.cs
+++ b/TournamentManager/TournamentManager.Tests/Importers/ExcludeDates/InternetCalendarImporterTests.cs
@@ -33,6 +33,7 @@ public class InternetCalendarImporterTests
         var icsFilePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Assets", "School_Holidays_Bavaria_2024.ics");
 
         var encoding = Encoding.UTF8;
+        // Test with a stream
         var iCalendarStream = new MemoryStream(encoding.GetBytes(File.ReadAllText(icsFilePath, Encoding.UTF8)))
         {
             Position = 0

--- a/TournamentManager/TournamentManager/Match/Calendar.cs
+++ b/TournamentManager/TournamentManager/Match/Calendar.cs
@@ -13,10 +13,7 @@ public class Calendar
 
     public Calendar()
     {
-        _calendar.ProductId = "TournamentManager/Ical.Net"; // Does not appear in output
-
         // Don't use this: Organizer = new Organizer() { CommonName = "TournamentManager", Value = new Uri("mailto:noreply@tournamentmanager")};
-        // Does not work well: _calendar.AddTimeZone(new VTimeZone("Europe/Berlin"));
 
         FirstAlarm = new TimeSpan(-7, 0, 0, 0, 0);
         SecondAlarm = new TimeSpan(-1, 0, 0, 0, 0);
@@ -71,8 +68,9 @@ public class Calendar
     /// Creates a calendar event for the matches.
     /// </summary>
     /// <param name="matches">The matches to use for the calendar events.</param>
+    /// <param name="tzId">The timezone Id.</param>
     /// <returns>Returns a <see cref="Ical.Net.Calendar"/> instance.</returns>
-    public Calendar CreateEvents(List<CalendarRow> matches)
+    public Calendar CreateEvents(List<CalendarRow> matches, string tzId)
     {
         // Don't set Calendar.Method to "PUBLISH"
         if (matches.Count > 1)
@@ -83,6 +81,9 @@ public class Calendar
             
         foreach (var match in matches)
         {
+            if (match.PlannedStart == null || match.PlannedEnd == null)
+                throw new InvalidOperationException("PlannedStart and PlannedEnd must not be null for calendar events.");
+
             var evt = _calendar.Create<CalendarEvent>();
                 
             evt.Summary = Summary;
@@ -96,13 +97,12 @@ public class Calendar
                     match.VenueLongitude.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));
             evt.Description += "\n" + DescriptionFooter;
             evt.Sequence = (int)match.ChangeSerial;
-            evt.Start = new CalDateTime(value: match.PlannedStart ?? throw new InvalidOperationException($"{nameof(match.PlannedStart)} must not be null"));
-            evt.End = new CalDateTime(value: match.PlannedEnd ?? throw new InvalidOperationException($"{nameof(match.PlannedEnd)} must not be null"));
+            evt.Start = new CalDateTime(value: match.PlannedStart.Value, tzId);
+            evt.End = new CalDateTime(value: match.PlannedEnd.Value, tzId);
             // evt.Created = new CalDateTime(match.ModifiedOn);
-            evt.LastModified = new CalDateTime(match.ModifiedOn);
-            evt.DtStamp = new CalDateTime(DateTime.Now);
+            evt.LastModified = new CalDateTime(match.ModifiedOn, "UTC");
+            evt.DtStamp = new CalDateTime(DateTime.UtcNow);
 
-            evt.IsAllDay = false;
             evt.Uid = string.Format(UidFormat, match.Id);
             evt.Status = EventStatus.Confirmed;
             evt.Class = "PRIVATE";
@@ -112,20 +112,20 @@ public class Calendar
             if (WithAlarms)
             {
                 // first alarm
-                evt.Alarms.Add(new Alarm()
+                evt.Alarms.Add(new Alarm
                     {
                         // Note: "Duration" property does NOT mean the length of the alarm ringing
-                        // but the TimeSpan before the event!
-                        Trigger = new Trigger(FirstAlarm),
+                        // but the time span before the event!
+                        Trigger = new Trigger { Duration = Duration.FromTimeSpanExact(FirstAlarm) },
                         Action = AlarmAction.Display,
                         Summary = evt.Summary
                     }
                 );
 
                 // second alarm
-                evt.Alarms.Add(new Alarm()
+                evt.Alarms.Add(new Alarm
                     {
-                        Trigger = new Trigger(SecondAlarm),
+                        Trigger = new Trigger { Duration = Duration.FromTimeSpanExact(SecondAlarm) },
                         Action = AlarmAction.Display,
                         Summary = evt.Summary
                     }
@@ -139,7 +139,10 @@ public class Calendar
     /// <summary>
     /// Creates a public calendar with events for the matches.
     /// </summary>
-    /// <param name="matches">The matches to use for the calendar events.</param>
+    /// <param name="matches">
+    /// The matches to use for the calendar events.
+    /// Date/time values must be in UTC.
+    /// </param>
     /// <returns>Returns a <see cref="Ical.Net.Calendar"/> instance.</returns>
     public Calendar CreatePublicCalendar(List<CalendarRow> matches)
     {
@@ -151,6 +154,9 @@ public class Calendar
 
         foreach (var match in matches)
         {
+            if (match.PlannedStart == null || match.PlannedEnd == null)
+                throw new InvalidOperationException("PlannedStart and PlannedEnd must not be null for calendar events.");
+
             var evt = _calendar.Create<CalendarEvent>();
 
             evt.Summary = Summary;
@@ -164,13 +170,12 @@ public class Calendar
                     match.VenueLongitude.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));
             evt.Description += "\n" + DescriptionFooter;
             evt.Sequence = (int)match.ChangeSerial;
-            evt.Start = new CalDateTime(value: match.PlannedStart ?? throw new InvalidOperationException($"{nameof(match.PlannedStart)} must not be null"));
-            evt.End = new CalDateTime(value: match.PlannedEnd ?? throw new InvalidOperationException($"{nameof(match.PlannedEnd)} must not be null"));
+            evt.Start = new CalDateTime(value: match.PlannedStart.Value, "UTC");
+            evt.End = new CalDateTime(value: match.PlannedEnd.Value, "UTC");
             // evt.Created = new CalDateTime(match.ModifiedOn);
-            evt.LastModified = new CalDateTime(match.ModifiedOn);
-            evt.DtStamp = new CalDateTime(DateTime.Now);
+            evt.LastModified = new CalDateTime(match.ModifiedOn, "UTC");
+            evt.DtStamp = new CalDateTime(DateTime.UtcNow);
 
-            evt.IsAllDay = false;
             evt.Uid = string.Format(UidFormat, match.Id);
             evt.Class = "PUBLIC";
 
@@ -179,10 +184,10 @@ public class Calendar
                 // first alarm
                 evt.Alarms.Add(new Alarm()
                     {
-                        // Note: "Duration" property does NOT mean the length of the alarm ringing
-                        // but the TimeSpan before the event!
-                        Trigger = new Trigger(FirstAlarm),
-                        Action = AlarmAction.Display,
+                    // Note: "Duration" property does NOT mean the length of the alarm ringing
+                    // but the time span before the event!
+                    Trigger = new Trigger { Duration = Duration.FromTimeSpanExact(FirstAlarm) },
+                    Action = AlarmAction.Display,
                         Summary = evt.Summary
                     }
                 );
@@ -190,8 +195,8 @@ public class Calendar
                 // second alarm
                 evt.Alarms.Add(new Alarm()
                     {
-                        Trigger = new Trigger(SecondAlarm),
-                        Action = AlarmAction.Display,
+                    Trigger = new Trigger { Duration = Duration.FromTimeSpanExact(SecondAlarm) },
+                    Action = AlarmAction.Display,
                         Summary = evt.Summary
                     }
                 );
@@ -203,24 +208,41 @@ public class Calendar
 
     public override string ToString()
     {
-        var serializer = new CalendarSerializer(new SerializationContext());
-        return serializer.SerializeToString(_calendar);
+        return new CalendarSerializer().SerializeToString(_calendar)!;
     }
 
-    public void Serialize(string filename, Encoding encoding)
+    /// <summary>
+    /// Serializes the calendar to a file.
+    /// </summary>
+    /// <param name="filename">The name of the file to write the calendar to.</param>
+    /// <param name="encoding">
+    /// RFC5545 sect. 3.4.1: iCal default charset is UTF8.
+    /// The encoding to use for the calendar text. If <c>null</c>, UTF-8 without BOM is used.
+    /// Important: no Byte Order Mark (BOM) for Android, Google, Apple
+    /// </param>
+    public void Serialize(string filename, Encoding? encoding = null)
     {
-        var serializer = new CalendarSerializer(new SerializationContext());
+        encoding ??= new UTF8Encoding(false);
         var ms = new MemoryStream();
-        serializer.Serialize(_calendar, ms, encoding);
+        new CalendarSerializer().Serialize(_calendar, ms, encoding);
         ms.Seek(0, SeekOrigin.Begin);
         var fs = File.Create(filename);
         ms.CopyTo(fs);
         fs.Close();
     }
 
-    public void Serialize(Stream stream, Encoding encoding)
+    /// <summary>
+    /// Serializes the calendar to a <see cref="Stream"/>.
+    /// </summary>
+    /// <param name="stream">The <see cref="Stream"/> to write the calendar to. The stream must be writable.</param>
+    /// <param name="encoding">
+    /// RFC5545 sect. 3.4.1: iCal default charset is UTF8.
+    /// The encoding to use for the calendar text. If <c>null</c>, UTF-8 without BOM is used.
+    /// Important: no Byte Order Mark (BOM) for Android, Google, Apple
+    /// </param>
+    public void Serialize(Stream stream, Encoding? encoding = null)
     {
-        var serializer = new CalendarSerializer(new SerializationContext());
-        serializer.Serialize(_calendar, stream, encoding);
+        encoding ??= new UTF8Encoding(false);
+        new CalendarSerializer().Serialize(_calendar, stream, encoding);
     }
 }

--- a/TournamentManager/TournamentManager/TournamentManager.csproj
+++ b/TournamentManager/TournamentManager/TournamentManager.csproj
@@ -29,7 +29,7 @@ Volleyball League is an open source sports platform that brings everything neces
     <PackageReference Include="PuppeteerSharp" Version="20.1.3" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <!-- Replace original Ical.Net v4.2.0 with more up-to-date fork -->
-    <PackageReference Include="Ical.Net" Version="4.3.1" />
+    <PackageReference Include="Ical.Net" Version="5.0.0" />
     <PackageReference Include="libphonenumber-csharp" Version="9.0.7" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.5.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />


### PR DESCRIPTION
- **Calendar events now use UTC date/times:** All iCalendar events for planned matches are generated with UTC date/times. This ensures consistency and avoids ambiguity, as match date/times are already stored in UTC.

- **Upgraded to Ical.Net 5.0.0:** The `TournamentManager` project now references `Ical.Net` version 5.0.0, benefiting from new features and bug fixes. ⚠️ **Note:** This upgrade introduces breaking changes. The codebase has been updated to accommodate the new API.

- **Fix**: Exclude `Match`es without `PlaennedStart` and `PlannedEnd` from context menu "Save match to calendar"

- Updated unit tests

- Added and updated XML documentation for calendar serialization methods.