### PR TITLE
Replaced static `TournamentEntity.IsPlanningMode` with dynamic calculaction

### DIFF
--- a/TournamentManager/DAL/DatabaseGeneric/EntityClasses/TournamentEntity.cs
+++ b/TournamentManager/DAL/DatabaseGeneric/EntityClasses/TournamentEntity.cs
@@ -249,9 +249,10 @@ namespace TournamentManager.DAL.EntityClasses
 			set { SetValue((int)TournamentFieldIndex.IsComplete, value); }
 		}
 
-		/// <summary>The IsPlanningMode property of the Entity Tournament<br/><br/></summary>
-		/// <remarks>Mapped on  table field: "Tournament"."IsPlanningMode".<br/>Table field type characteristics (type, precision, scale, length): Bit, 0, 0, 0.<br/>Table field behavior characteristics (is nullable, is PK, is identity): false, false, false</remarks>
-		public virtual System.Boolean IsPlanningMode
+        /// <summary>The IsPlanningMode property of the Entity Tournament<br/><br/></summary>
+        /// <remarks>Mapped on  table field: "Tournament"."IsPlanningMode".<br/>Table field type characteristics (type, precision, scale, length): Bit, 0, 0, 0.<br/>Table field behavior characteristics (is nullable, is PK, is identity): false, false, false</remarks>
+        [Obsolete("This property has been replaced with 'IsPlanningMode(TournamentEntity, CancellationToken)' will be removed in a future version.", true)]
+        public virtual System.Boolean IsPlanningMode
 		{
 			get { return (System.Boolean)GetValue((int)TournamentFieldIndex.IsPlanningMode, true); }
 			set { SetValue((int)TournamentFieldIndex.IsPlanningMode, value); }

--- a/TournamentManager/TournamentManager/TournamentCreator.cs
+++ b/TournamentManager/TournamentManager/TournamentCreator.cs
@@ -122,23 +122,15 @@ public class TournamentCreator
         {
             _logger.LogWarning("Safety checks disabled.");
         }
-        else
+        else if (sourceTournament.NextTournamentId.HasValue)
         {
-            if (sourceTournament.IsPlanningMode)
-            {
-                throw new InvalidOperationException($"Source tournament {sourceTournament.Id} is in planning mode.");
-            }
-
-            if (sourceTournament.NextTournamentId.HasValue)
-            {
-                throw new InvalidOperationException($"Source tournament {sourceTournament.Id} has already a next tournament.");
-            }
+            throw new InvalidOperationException(
+                $"Source tournament {sourceTournament.Id} has already a next tournament.");
         }
 
         // Create the target tournament
         var targetTournament = new TournamentEntity
         {
-            IsPlanningMode = true,
             Name = copyArgs.TargetName,
             Description = copyArgs.TargetDescription,
             TypeId = sourceTournament.TypeId,


### PR DESCRIPTION
- Updated `EnterResult` and `EditFixture` methods of `Match` controller to use asynchronous checks for tournament planning mode
- Marked the old `IsPlanningMode` property in `TournamentEntity` as obsolete to guide developers towards the new method.
- Enhanced `GetTournamentStartAsync` in `RoundRepository` with new asynchronous methods for retrieving round and tournament start dates.
- Simplified validation logic in `TournamentCreator.cs` by removing the planning mode check and directly throwing exceptions for invalid tournament states.