### PR TITLE
chore `ModelValidator`s async method calls use `.ConfigureAwait(false)`

### DIFF
--- a/TournamentManager/TournamentManager/ModelValidators/AbstractValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/AbstractValidator.cs
@@ -165,7 +165,7 @@ public abstract class AbstractValidator<TModel, TData, TFactId>
     /// <summary>
     /// Gets the <see cref="HashSet{T}"/> of <see cref="Facts"/> for the validator.
     /// </summary>
-    public HashSet<Fact<TFactId>> Facts { get; } = new();
+    public HashSet<Fact<TFactId>> Facts { get; } = [];
 
     /// <summary>
     /// Get all facts of a certain <see cref="FactType"/>.

--- a/TournamentManager/TournamentManager/ModelValidators/MatchResultPermissionValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/MatchResultPermissionValidator.cs
@@ -31,7 +31,7 @@ public class MatchResultPermissionValidator : AbstractValidator<MatchEntity, (IT
         return new Fact<FactId>
         {
             Id = FactId.CurrentDateIsBeforeResultCorrectionDeadline,
-            FieldNames = new[] { string.Empty },
+            FieldNames = [string.Empty],
             Enabled = true,
             Type = FactType.Critical,
             CheckAsync = (cancellationToken) => FactResult()
@@ -70,7 +70,7 @@ public class MatchResultPermissionValidator : AbstractValidator<MatchEntity, (IT
         return new Fact<FactId>
         {
             Id = FactId.RoundIsStillRunning,
-            FieldNames = new[] { string.Empty },
+            FieldNames = [string.Empty],
             Enabled = true,
             Type = FactType.Critical,
             CheckAsync = (cancellationToken) => Task.FromResult(
@@ -88,7 +88,7 @@ public class MatchResultPermissionValidator : AbstractValidator<MatchEntity, (IT
         return new Fact<FactId>
         {
             Id = FactId.TournamentIsInActiveMode,
-            FieldNames = new[] {string.Empty},
+            FieldNames = [string.Empty],
             Enabled = true,
             Type = FactType.Critical,
             CheckAsync = (cancellationToken) => Task.FromResult(

--- a/TournamentManager/TournamentManager/ModelValidators/MatchResultValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/MatchResultValidator.cs
@@ -72,8 +72,8 @@ public sealed class MatchResultValidator : AbstractValidator<MatchEntity, (ITena
             // One ball point lasts for about 33 seconds (average over 1,024 matches with 169,845 ball points in 92,186 minutes)
             // https://volleyball.de/nc/news/details/datum/2011/05/27/zahlenspiele-1025-spiele-dauerten-64-tage-und-26-minuten/
             Id = FactId.RealMatchDurationIsPlausible,
-            FieldNames = new[] { nameof(Model.RealStart), nameof(Model.RealEnd) },
-            Enabled = default,
+            FieldNames = [nameof(Model.RealStart), nameof(Model.RealEnd)],
+            Enabled = false,
             Type = FactType.Warning,
             CheckAsync = (cancellationToken) => FactResult()
         };
@@ -101,8 +101,8 @@ public sealed class MatchResultValidator : AbstractValidator<MatchEntity, (ITena
         return new Fact<FactId>
         {
             Id = FactId.RealMatchDateEqualsFixture,
-            FieldNames = new[] { nameof(Model.RealStart), nameof(Model.RealEnd) },
-            Enabled = default,
+            FieldNames = [nameof(Model.RealStart), nameof(Model.RealEnd)],
+            Enabled = false,
             Type = FactType.Warning,
             CheckAsync = (cancellationToken) => Task.FromResult(
                 new FactResult
@@ -119,15 +119,15 @@ public sealed class MatchResultValidator : AbstractValidator<MatchEntity, (ITena
         return new Fact<FactId>
         {
             Id = FactId.SetsValidatorSuccessful,
-            FieldNames = new[] { string.Empty },
-            Enabled = default,
+            FieldNames = [string.Empty],
+            Enabled = false,
             Type = FactType.Critical,
-            CheckAsync = async (cancellationToken) => await FactResult()
+            CheckAsync = async (cancellationToken) => await FactResult().ConfigureAwait(false)
         };
 
         async Task<FactResult> FactResult()
         {
-            await SetsValidator.CheckAsync(CancellationToken.None);
+            await SetsValidator.CheckAsync(CancellationToken.None).ConfigureAwait(false);
 
             return new FactResult
             {
@@ -143,13 +143,13 @@ public sealed class MatchResultValidator : AbstractValidator<MatchEntity, (ITena
         return new Fact<FactId>
         {
             Id = FactId.RealMatchDateWithinRoundLegs,
-            FieldNames = new[] {nameof(Model.RealStart), nameof(Model.RealEnd) },
-            Enabled = default,
+            FieldNames = [nameof(Model.RealStart), nameof(Model.RealEnd)],
+            Enabled = false,
             Type = FactType.Error,
             CheckAsync = FactResult
         };
 
-    async Task<FactResult> FactResult(CancellationToken cancellationToken)
+        async Task<FactResult> FactResult(CancellationToken cancellationToken)
         {
             var successResult = new FactResult
             {
@@ -158,8 +158,9 @@ public sealed class MatchResultValidator : AbstractValidator<MatchEntity, (ITena
             };
 
             var round =
-                await Data.TenantContext.DbContext.AppDb.RoundRepository.GetRoundWithLegsAsync(Model.RoundId,
-                    cancellationToken) ?? throw new InvalidOperationException($"Round Id '{Model.RoundId}' not found.");
+                await Data.TenantContext.DbContext.AppDb.RoundRepository
+                    .GetRoundWithLegsAsync(Model.RoundId, cancellationToken).ConfigureAwait(false)
+                ?? throw new InvalidOperationException($"Round Id '{Model.RoundId}' not found.");
 
             if (!Model.RealStart.HasValue || !Model.RealEnd.HasValue || round.RoundLegs.Count == 0)
             {
@@ -198,8 +199,8 @@ public sealed class MatchResultValidator : AbstractValidator<MatchEntity, (ITena
         return new Fact<FactId>
         {
             Id = FactId.RealMatchDateTodayOrBefore,
-            FieldNames = new[] { nameof(Model.RealStart), nameof(Model.RealEnd) },
-            Enabled = default,
+            FieldNames = [nameof(Model.RealStart), nameof(Model.RealEnd)],
+            Enabled = false,
             Type = FactType.Error,
             CheckAsync = (cancellationToken) => Task.FromResult(
                 new FactResult
@@ -215,8 +216,8 @@ public sealed class MatchResultValidator : AbstractValidator<MatchEntity, (ITena
         return new Fact<FactId>
         {
             Id = FactId.RealMatchDateIsSet,
-            FieldNames = new[] { nameof(Model.RealStart), nameof(Model.RealEnd) },
-            Enabled = default,
+            FieldNames = [nameof(Model.RealStart), nameof(Model.RealEnd)],
+            Enabled = false,
             Type = FactType.Critical,
             CheckAsync = (cancellationToken) => Task.FromResult(
                 new FactResult
@@ -232,8 +233,8 @@ public sealed class MatchResultValidator : AbstractValidator<MatchEntity, (ITena
         return new Fact<FactId>
         {
             Id = FactId.MatchPointsAreValid,
-            FieldNames = new[] { nameof(Model.HomePoints), nameof(Model.GuestPoints) },
-            Enabled = default,
+            FieldNames = [nameof(Model.HomePoints), nameof(Model.GuestPoints)],
+            Enabled = false,
             Type = FactType.Critical,
             CheckAsync = (cancellationToken) =>
             {
@@ -247,7 +248,8 @@ public sealed class MatchResultValidator : AbstractValidator<MatchEntity, (ITena
                 }.Distinct().ToList();
 
                 return Task.FromResult(
-                    new FactResult {
+                    new FactResult
+                    {
                         Message = string.Format(MatchResultValidatorResource.ResourceManager.GetString(
                                                     nameof(FactId.MatchPointsAreValid)) ??
                                                 string.Empty, string.Join(',', allowed)),

--- a/TournamentManager/TournamentManager/ModelValidators/PhoneNumberValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/PhoneNumberValidator.cs
@@ -25,7 +25,7 @@ public class PhoneNumberValidator : AbstractValidator<string, (PhoneNumberServic
         return new Fact<FactId>
         {
             Id = FactId.NumberIsValid,
-            FieldNames = new[] {"PhoneNumber"},
+            FieldNames = ["PhoneNumber"],
             Enabled = true,
             Type = FactType.Critical,
             CheckAsync = (cancellationToken) => Task.FromResult(

--- a/TournamentManager/TournamentManager/ModelValidators/SetsValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/SetsValidator.cs
@@ -46,7 +46,8 @@ public sealed class SetsValidator : AbstractValidator<IList<SetEntity>, (ITenant
         ConfigureFacts(ModeConfiguration[validationMode]);
     }
 
-    public List<(long Id, int SequenceNo, SingleSetValidator.FactId FactId, string ErrorMessage)> SingleSetErrors { get; } = new();
+    public List<(long Id, int SequenceNo, SingleSetValidator.FactId FactId, string ErrorMessage)> SingleSetErrors { get; } =
+        [];
 
     private void CreateFacts()
     {
@@ -62,11 +63,10 @@ public sealed class SetsValidator : AbstractValidator<IList<SetEntity>, (ITenant
         return new Fact<FactId>
         {
             Id = FactId.BestOfNoMatchAfterBestOfReached,
-            FieldNames = new[] { nameof(MatchEntity.Sets) },
+            FieldNames = [nameof(MatchEntity.Sets)],
             Enabled = true,
             Type = FactType.Error,
-            CheckAsync = async (cancellationToken) =>
-            await FactResult()
+            CheckAsync = async (cancellationToken) => await FactResult().ConfigureAwait(false)
         };
 
         async Task<FactResult> FactResult()
@@ -81,12 +81,13 @@ public sealed class SetsValidator : AbstractValidator<IList<SetEntity>, (ITenant
 
             var numOfWins = new PointResult(0, 0);
             var bestOfReachedButSetsFollow = false;
-            for (var i=0; i < Model.Count; i++)
+            for (var i = 0; i < Model.Count; i++)
             {
                 if (Model[i].HomeBallPoints < Model[i].GuestBallPoints)
                 {
                     numOfWins.Guest++;
-                } else if (Model[i].HomeBallPoints > Model[i].GuestBallPoints)
+                }
+                else if (Model[i].HomeBallPoints > Model[i].GuestBallPoints)
                 {
                     numOfWins.Home++;
                 }
@@ -104,7 +105,7 @@ public sealed class SetsValidator : AbstractValidator<IList<SetEntity>, (ITenant
                 factResult.Success = !bestOfReachedButSetsFollow;
             }
 
-            return await Task.FromResult(factResult);
+            return await Task.FromResult(factResult).ConfigureAwait(false);
         }
     }
 
@@ -113,7 +114,7 @@ public sealed class SetsValidator : AbstractValidator<IList<SetEntity>, (ITenant
         return new Fact<FactId>
         {
             Id = FactId.BestOfRequiredTieBreakPlayed,
-            FieldNames = new[] { nameof(MatchEntity.Sets) },
+            FieldNames = [nameof(MatchEntity.Sets)],
             Enabled = true,
             Type = FactType.Error,
             CheckAsync = (cancellationToken) => FactResult()
@@ -143,7 +144,7 @@ public sealed class SetsValidator : AbstractValidator<IList<SetEntity>, (ITenant
         return new Fact<FactId>
         {
             Id = FactId.AllSetsAreValid,
-            FieldNames = new[] { nameof(MatchEntity.Sets) },
+            FieldNames = [nameof(MatchEntity.Sets)],
             Enabled = true,
             Type = FactType.Critical,
             CheckAsync = FactResult
@@ -155,7 +156,7 @@ public sealed class SetsValidator : AbstractValidator<IList<SetEntity>, (ITenant
             {
                 var singleSetValidator =
                     new SingleSetValidator(set, (Data.TenantContext, Data.Rules.SetRule), _validationMode);
-                await singleSetValidator.CheckAsync(cancellationToken);
+                await singleSetValidator.CheckAsync(cancellationToken).ConfigureAwait(false);
                 var errorFact = singleSetValidator.GetFailedFacts().FirstOrDefault();
                 if (errorFact != null)
                 {
@@ -177,7 +178,7 @@ public sealed class SetsValidator : AbstractValidator<IList<SetEntity>, (ITenant
         return new Fact<FactId>
         {
             Id = FactId.BestOfMinAndMaxOfSetsPlayed,
-            FieldNames = new[] { nameof(MatchEntity.Sets) },
+            FieldNames = [nameof(MatchEntity.Sets)],
             Enabled = true,
             Type = FactType.Critical,
             CheckAsync = (cancellationToken) => Task.FromResult(
@@ -196,7 +197,7 @@ public sealed class SetsValidator : AbstractValidator<IList<SetEntity>, (ITenant
         return new Fact<FactId>
         {
             Id = FactId.MinAndMaxOfSetsPlayed,
-            FieldNames = new[] { nameof(MatchEntity.Sets) },
+            FieldNames = [nameof(MatchEntity.Sets)],
             Enabled = true,
             Type = FactType.Critical,
             CheckAsync = (cancellationToken) => Task.FromResult(

--- a/TournamentManager/TournamentManager/ModelValidators/SingleSetValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/SingleSetValidator.cs
@@ -80,8 +80,8 @@ public sealed class SingleSetValidator : AbstractValidator<SetEntity, (ITenantCo
         return new Fact<FactId>
         {
             Id = FactId.TieBreakWinReachedWithTwoPlusPointsAhead,
-            FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
-            Enabled = default,
+            FieldNames = [nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)],
+            Enabled = false,
             Type = FactType.Error,
             CheckAsync = (cancellationToken) => FactResult()
         };
@@ -149,8 +149,8 @@ public sealed class SingleSetValidator : AbstractValidator<SetEntity, (ITenantCo
         return new Fact<FactId>
         {
             Id = FactId.TieBreakWinReachedWithOnePointAhead,
-            FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
-            Enabled = default,
+            FieldNames = [nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)],
+            Enabled = false,
             Type = FactType.Error,
             CheckAsync = (cancellationToken) => FactResult()
         };
@@ -188,8 +188,8 @@ public sealed class SingleSetValidator : AbstractValidator<SetEntity, (ITenantCo
         return new Fact<FactId>
         {
             Id = FactId.RegularWinReachedWithTwoPlusPointsAhead,
-            FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
-            Enabled = default,
+            FieldNames = [nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)],
+            Enabled = false,
             Type = FactType.Error,
             CheckAsync = (cancellationToken) => FactResult()
         };
@@ -258,8 +258,8 @@ public sealed class SingleSetValidator : AbstractValidator<SetEntity, (ITenantCo
         return new Fact<FactId>
         {
             Id = FactId.RegularWinReachedWithOnePointAhead,
-            FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
-            Enabled = default,
+            FieldNames = [nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)],
+            Enabled = false,
             Type = FactType.Error,
             CheckAsync = (cancellationToken) => FactResult()
         };
@@ -297,8 +297,8 @@ public sealed class SingleSetValidator : AbstractValidator<SetEntity, (ITenantCo
         return new Fact<FactId>
         {
             Id = FactId.NumOfPointsToWinReached,
-            FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
-            Enabled = default,
+            FieldNames = [nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)],
+            Enabled = false,
             Type = FactType.Error,
             CheckAsync = (cancellationToken) => Task.FromResult(
                 Model.IsTieBreak
@@ -328,8 +328,8 @@ public sealed class SingleSetValidator : AbstractValidator<SetEntity, (ITenantCo
         return new Fact<FactId>
         {
             Id = FactId.TieIsAllowed,
-            FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
-            Enabled = default,
+            FieldNames = [nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)],
+            Enabled = false,
             Type = FactType.Error,
             CheckAsync = (cancellationToken) => FactResult()
         };
@@ -367,8 +367,8 @@ public sealed class SingleSetValidator : AbstractValidator<SetEntity, (ITenantCo
         return new Fact<FactId>
         {
             Id = FactId.BallPointsNotNegative,
-            FieldNames = new[] {nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)},
-            Enabled = default,
+            FieldNames = [nameof(Model.HomeBallPoints), nameof(Model.GuestBallPoints)],
+            Enabled = false,
             Type = FactType.Critical,
             CheckAsync = (cancellationToken) => Task.FromResult(
                 new FactResult
@@ -385,8 +385,8 @@ public sealed class SingleSetValidator : AbstractValidator<SetEntity, (ITenantCo
         return new Fact<FactId>
         {
             Id = FactId.SetPointsAreValid,
-            FieldNames = new[] { nameof(Model.HomeSetPoints), nameof(Model.GuestSetPoints) },
-            Enabled = default,
+            FieldNames = [nameof(Model.HomeSetPoints), nameof(Model.GuestSetPoints)],
+            Enabled = false,
             Type = FactType.Critical,
             CheckAsync = (cancellationToken) =>
             {

--- a/TournamentManager/TournamentManager/ModelValidators/TeamInRoundValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/TeamInRoundValidator.cs
@@ -27,7 +27,7 @@ public class TeamInRoundValidator : AbstractValidator<TeamInRoundEntity, (ITenan
         return new Fact<FactId>
         {
             Id = FactId.RoundBelongsToTournament,
-            FieldNames = new[] {nameof(Model.RoundId)},
+            FieldNames = [nameof(Model.RoundId)],
             Enabled = true,
             Type = FactType.Critical,
             CheckAsync = FactResult
@@ -37,7 +37,7 @@ public class TeamInRoundValidator : AbstractValidator<TeamInRoundEntity, (ITenan
         {
             var roundWithTypeList = await Data.TenantContext.DbContext.AppDb.RoundRepository.GetRoundsWithTypeAsync(
                 new PredicateExpression(RoundFields.TournamentId == Data.TouramentId),
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
 
             if (roundWithTypeList.Exists(round => round.Id == Model.RoundId))
             {
@@ -50,7 +50,7 @@ public class TeamInRoundValidator : AbstractValidator<TeamInRoundEntity, (ITenan
                         
             var tournament =
                 await Data.TenantContext.DbContext.AppDb.TournamentRepository.GetTournamentAsync(new PredicateExpression(TournamentFields.Id == Data.TouramentId),
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
 
             return new FactResult
             {

--- a/TournamentManager/TournamentManager/ModelValidators/TeamValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/TeamValidator.cs
@@ -34,7 +34,7 @@ public class TeamValidator : AbstractValidator<TeamEntity, ITenantContext, TeamV
         return new Fact<FactId>
         {
             Id = FactId.MatchTimeWithinRange,
-            FieldNames = new[] {nameof(Model.MatchTime)},
+            FieldNames = [nameof(Model.MatchTime)],
             Enabled = Data.TournamentContext.TeamRuleSet.HomeMatchTime.MustBeSet,
             Type = FactType.Warning,
             CheckAsync = (cancellationToken) => Task.FromResult(
@@ -57,7 +57,7 @@ public class TeamValidator : AbstractValidator<TeamEntity, ITenantContext, TeamV
         return new Fact<FactId>
         {
             Id = FactId.DayOfWeekWithinRange,
-            FieldNames = new[] {nameof(Model.MatchDayOfWeek)},
+            FieldNames = [nameof(Model.MatchDayOfWeek)],
             Enabled = Data.TournamentContext.TeamRuleSet.HomeMatchTime is { IsEditable: true, MustBeSet: true },
             Type = Data.TournamentContext.TeamRuleSet.HomeMatchTime.ErrorIfNotInDaysOfWeekRange
                 ? FactType.Error
@@ -81,7 +81,7 @@ public class TeamValidator : AbstractValidator<TeamEntity, ITenantContext, TeamV
         return new Fact<FactId>
         {
             Id = FactId.MatchDayOfWeekAndTimeIsSet,
-            FieldNames = new[] {nameof(Model.MatchDayOfWeek), nameof(Model.MatchTime)},
+            FieldNames = [nameof(Model.MatchDayOfWeek), nameof(Model.MatchTime)],
             Enabled = Data.TournamentContext.TeamRuleSet.HomeMatchTime is { IsEditable: true },
             Type = FactType.Critical,
             CheckAsync = (cancellationToken) => Task.FromResult(
@@ -100,7 +100,7 @@ public class TeamValidator : AbstractValidator<TeamEntity, ITenantContext, TeamV
         return new Fact<FactId>
         {
             Id = FactId.TeamNameIsUnique,
-            FieldNames = new[] { nameof(Model.Name) },
+            FieldNames = [nameof(Model.Name)],
             Enabled = !string.IsNullOrEmpty(Model.Name),
             Type = FactType.Critical,
             CheckAsync = FactResult
@@ -108,7 +108,8 @@ public class TeamValidator : AbstractValidator<TeamEntity, ITenantContext, TeamV
 
         async Task<FactResult> FactResult(CancellationToken cancellationToken)
         {
-            var teamName = await Data.DbContext.AppDb.TeamRepository.TeamNameExistsAsync(Model, cancellationToken);
+            var teamName = await Data.DbContext.AppDb.TeamRepository.TeamNameExistsAsync(Model, cancellationToken)
+                .ConfigureAwait(false);
             return new FactResult
             {
                 Message = string.Format(TeamValidatorResource.ResourceManager.GetString(
@@ -123,7 +124,7 @@ public class TeamValidator : AbstractValidator<TeamEntity, ITenantContext, TeamV
         return new Fact<FactId>
         {
             Id = FactId.TeamNameIsSet,
-            FieldNames = new[] { nameof(Model.Name) },
+            FieldNames = [nameof(Model.Name)],
             Enabled = true,
             Type = FactType.Critical,
             CheckAsync = (cancellationToken) => Task.FromResult(

--- a/TournamentManager/TournamentManager/ModelValidators/TeamVenueValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/TeamVenueValidator.cs
@@ -27,7 +27,7 @@ public class TeamVenueValidator : AbstractValidator<TeamEntity, ITenantContext, 
         return new Fact<FactId>
         {
             Id = FactId.VenueIsValid,
-            FieldNames = new[] {nameof(Model.VenueId)},
+            FieldNames = [nameof(Model.VenueId)],
             Enabled = Model.VenueId.HasValue,
             Type = FactType.Critical,
             CheckAsync = async (cancellationToken) => new FactResult {
@@ -35,7 +35,7 @@ public class TeamVenueValidator : AbstractValidator<TeamEntity, ITenantContext, 
                     nameof(FactId.VenueIsValid)) ?? string.Empty,
                 Success = Model.VenueId.HasValue &&
                           await Data.DbContext.AppDb.VenueRepository.IsValidVenueIdAsync(Model.VenueId,
-                              cancellationToken)
+                              cancellationToken).ConfigureAwait(false)
             }
         };
     }
@@ -45,7 +45,7 @@ public class TeamVenueValidator : AbstractValidator<TeamEntity, ITenantContext, 
         return new Fact<FactId>
         {
             Id = FactId.VenueIsSetIfRequired,
-            FieldNames = new[] {nameof(Model.VenueId)},
+            FieldNames = [nameof(Model.VenueId)],
             Enabled = true,
             Type = FactType.Critical,
             CheckAsync = (cancellationToken) => Task.FromResult(

--- a/TournamentManager/TournamentManager/ModelValidators/VenueValidator.cs
+++ b/TournamentManager/TournamentManager/ModelValidators/VenueValidator.cs
@@ -39,7 +39,7 @@ public class VenueValidator : AbstractValidator<VenueEntity, (GoogleGeo.GeoRespo
         return new Fact<FactId>
         {
             Id = FactId.NotExistingGeoLocation,
-            FieldNames = new[] { nameof(Model.Name) },
+            FieldNames = [nameof(Model.Name)],
             Enabled = Data.GeoResponse is { Success: true, Found: true },
             Type = FactType.Warning,
             CheckAsync = cancellationToken => FactResult()
@@ -71,7 +71,7 @@ public class VenueValidator : AbstractValidator<VenueEntity, (GoogleGeo.GeoRespo
         return new Fact<FactId>
         {
             Id = FactId.LocationIsPrecise,
-            FieldNames = new[] { nameof(Model.PostalCode), nameof(Model.City), nameof(Model.Street) },
+            FieldNames = [nameof(Model.PostalCode), nameof(Model.City), nameof(Model.Street)],
             Enabled = Data.GeoResponse is { Success: true, Found: true },
             Type = FactType.Warning,
             CheckAsync = (cancellationToken) => Task.FromResult(
@@ -88,7 +88,7 @@ public class VenueValidator : AbstractValidator<VenueEntity, (GoogleGeo.GeoRespo
         return new Fact<FactId>
         {
             Id = FactId.CanBeLocated,
-            FieldNames = new[] { nameof(Model.PostalCode), nameof(Model.City), nameof(Model.Street) },
+            FieldNames = [nameof(Model.PostalCode), nameof(Model.City), nameof(Model.Street)],
             Enabled = Data.GeoResponse.Success,
             Type = FactType.Warning,
             CheckAsync = (cancellationToken) => Task.FromResult(
@@ -105,7 +105,7 @@ public class VenueValidator : AbstractValidator<VenueEntity, (GoogleGeo.GeoRespo
         return new Fact<FactId>
         {
             Id = FactId.AddressFieldsAreSet,
-            FieldNames = new[] { nameof(Model.PostalCode), nameof(Model.City), nameof(Model.Street) },
+            FieldNames = [nameof(Model.PostalCode), nameof(Model.City), nameof(Model.Street)],
             Enabled = true,
             Type = FactType.Error,
             CheckAsync = (cancellationToken) => Task.FromResult(
@@ -122,7 +122,7 @@ public class VenueValidator : AbstractValidator<VenueEntity, (GoogleGeo.GeoRespo
         return new Fact<FactId>
         {
             Id = FactId.NameIsSet,
-            FieldNames = new[] { nameof(Model.Name) },
+            FieldNames = [nameof(Model.Name)],
             Enabled = true,
             Type = FactType.Error,
             CheckAsync = (cancellationToken) => Task.FromResult(


### PR DESCRIPTION
Modified asynchronous method calls to include `.ConfigureAwait(false)` to enhance performance and mitigate potential deadlocks.