### PR TITLE
Update nuget packages

### DIFF
--- a/Axuno.BackgroundTask.Test/Axuno.BackgroundTask.Tests.csproj
+++ b/Axuno.BackgroundTask.Test/Axuno.BackgroundTask.Tests.csproj
@@ -5,9 +5,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.3.0" />
+    <PackageReference Include="FluentAssertions" Version="8.5.0" />
     <PackageReference Include="nunit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.9.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Axuno.BackgroundTask/Axuno.BackgroundTask.csproj
+++ b/Axuno.BackgroundTask/Axuno.BackgroundTask.csproj
@@ -17,6 +17,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
   </ItemGroup>
 </Project>

--- a/Axuno.Tools.Tests/Axuno.Tools.Tests.csproj
+++ b/Axuno.Tools.Tests/Axuno.Tools.Tests.csproj
@@ -20,13 +20,13 @@
     <EmbeddedResource Include="FileSystem\Data\my-json-file.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.3.0" />
+    <PackageReference Include="FluentAssertions" Version="8.5.0" />
     <PackageReference Include="nunit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.9.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Axuno.Web/Axuno.Web.csproj
+++ b/Axuno.Web/Axuno.Web.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.12.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.13.0" />
     <PackageReference Include="NuGetizer" Version="1.2.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/League.Tests/League.Tests.csproj
+++ b/League.Tests/League.Tests.csproj
@@ -5,23 +5,23 @@
     <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.18" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
-    <PackageReference Include="FluentAssertions" Version="8.3.0" />
+    <PackageReference Include="FluentAssertions" Version="8.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.9.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="ObjectsComparer" Version="1.4.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.13.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\League.Demo\League.Demo.csproj" />

--- a/League/League.csproj
+++ b/League/League.csproj
@@ -67,10 +67,10 @@ Localizations for English and German are included. The library is in operation o
         <PackageReference Include="Axuno.TextTemplating" Version="3.0.0" />
         <PackageReference Include="JSNLog" Version="3.0.3" />
         <PackageReference Include="MailMergeLib" Version="5.12.3" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.17" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.17" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.17" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.17" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.18" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.18" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.18" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.18" />
         <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
@@ -87,7 +87,7 @@ Localizations for English and German are included. The library is in operation o
         </PackageReference>
         <PackageReference Include="StackifyMiddleware" Version="3.3.3.4767" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.6" />
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.7" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
     <ItemGroup>

--- a/TournamentManager/DAL/DatabaseGeneric/TournamentManager.DAL.DbGeneric.csproj
+++ b/TournamentManager/DAL/DatabaseGeneric/TournamentManager.DAL.DbGeneric.csproj
@@ -12,6 +12,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SD.LLBLGen.Pro.ORMSupportClasses" Version="5.12.0" />
+    <PackageReference Include="SD.LLBLGen.Pro.ORMSupportClasses" Version="5.12.1" />
   </ItemGroup>
 </Project>

--- a/TournamentManager/DAL/DatabaseSpecific/TournamentManager.DAL.DBSpecific.csproj
+++ b/TournamentManager/DAL/DatabaseSpecific/TournamentManager.DAL.DBSpecific.csproj
@@ -11,6 +11,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SD.LLBLGen.Pro.DQE.SqlServer" Version="5.12.0" />
+    <PackageReference Include="SD.LLBLGen.Pro.DQE.SqlServer" Version="5.12.1" />
   </ItemGroup>
 </Project>

--- a/TournamentManager/TournamentManager.Tests/TournamentManager.Tests.csproj
+++ b/TournamentManager/TournamentManager.Tests/TournamentManager.Tests.csproj
@@ -6,11 +6,11 @@
     <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.3.0" />
+    <PackageReference Include="FluentAssertions" Version="8.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.9.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TournamentManager/TournamentManager/TournamentManager.csproj
+++ b/TournamentManager/TournamentManager/TournamentManager.csproj
@@ -17,7 +17,7 @@ Volleyball League is an open source sports platform that brings everything neces
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EPPlus" Version="8.0.5" />
+    <PackageReference Include="EPPlus" Version="8.0.7" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
     <PackageReference Include="NLog" Version="5.5.0" />
     <PackageReference Include="NuGetizer" Version="1.2.4">
@@ -26,10 +26,10 @@ Volleyball League is an open source sports platform that brings everything neces
     </PackageReference>
     <PackageReference Include="OxyPlot.Core" Version="2.2.0" />
     <PackageReference Include="OxyPlot.SkiaSharp" Version="2.2.0" />
-    <PackageReference Include="PuppeteerSharp" Version="20.1.3" />
+    <PackageReference Include="PuppeteerSharp" Version="20.2.2" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="Ical.Net" Version="5.1.0" />
-    <PackageReference Include="libphonenumber-csharp" Version="9.0.7" />
+    <PackageReference Include="libphonenumber-csharp" Version="9.0.10" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.5.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
     <PackageReference Include="YAXLib" Version="4.3.0" />


### PR DESCRIPTION
League:
* Microsoft.AspNetCore.Authentication.Facebook 8.0.17 → 8.0.18
* Microsoft.AspNetCore.Authentication.Google 8.0.17 → 8.0.18
* Microsoft.AspNetCore.Authentication.MicrosoftAccount 8.0.17 → 8.0.18
* Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation 8.0.17 → 8.0.18
* System.Security.Cryptography.Xml 9.0.6 → 9.0.7

TournamentManager:
* EEPlus 8.05 → 8.07
* PuppeteerSharp 20.1.3 → 20.2.2
* libphonenumber-csharp 9.0.7 → 9.0.10

Several package updates for test projects