### PR TITLE
feat: Confirmation of Team Application Contains Bank Reference ID

### DIFF
--- a/League.Tests/TextTemplating/EmailTemplateTests.cs
+++ b/League.Tests/TextTemplating/EmailTemplateTests.cs
@@ -121,6 +121,7 @@ public class EmailTemplateTests
                         RoundDescription = "Round description",
                         RoundTypeDescription = "6 ladies",
                         TeamName = "Team name",
+                        BankTransferId = "A3-T45-U67",
                         RegisteredByName = "Registered-by-name",
                         RegisteredByEmail = "email@registered-by.net",
                         IsRegisteringUser = isRegisteringUser,
@@ -134,7 +135,11 @@ public class EmailTemplateTests
             Assert.That(text, Does.Contain(L("Sporting greetings", cultureName)));
                     
             if(isRegisteringUser) Assert.That(text.Contains("Link", StringComparison.CurrentCultureIgnoreCase));
-            if(isRegisteringUser && showBank) Assert.That(text.Contains("Bank", StringComparison.CurrentCultureIgnoreCase) && text.Contains(_tenantContext.OrganizationContext.Bank.Amount.ToString(CultureInfo.GetCultureInfo(cultureName))));
+            if (isRegisteringUser && showBank)
+            {
+                Assert.That(text.Contains("Bank", StringComparison.CurrentCultureIgnoreCase) && text.Contains(_tenantContext.OrganizationContext.Bank.Amount.ToString(CultureInfo.GetCultureInfo(cultureName))));
+                Assert.That(text, Does.Contain(L("Reference ID", cultureName)));
+            }
         });
     }
         

--- a/League/Emailing/Creators/ConfirmTeamApplicationCreator.cs
+++ b/League/Emailing/Creators/ConfirmTeamApplicationCreator.cs
@@ -53,7 +53,8 @@ public class ConfirmTeamApplicationCreator : IMailMessageCreator
             RegisteredByName = registeredBy.CompleteName,
             RegisteredByEmail = registeredBy.Email,
             TeamName = teamUserRoundInfos.First(tur => tur.TeamId == Parameters.TeamId).TeamNameForRound,
-            TournamentName = tournament!.Name,
+            BankTransferId = $"A{tournament!.Id}-T{Parameters.TeamId}-U{registeredBy.UserId}",
+            TournamentName = tournament.Name,
             RoundDescription = roundWithType.Description,
             RoundTypeDescription = roundWithType.RoundType.Description,
             UrlToEditApplication = Parameters.UrlToEditApplication

--- a/League/Emailing/TemplateModels/ConfirmTeamApplicationModel.cs
+++ b/League/Emailing/TemplateModels/ConfirmTeamApplicationModel.cs
@@ -17,6 +17,10 @@ public class ConfirmTeamApplicationModel
     public string RoundTypeDescription { get; set; } = string.Empty;
     public string TeamName { get; set; } = string.Empty;
     /// <summary>
+    /// The ID that should be used for the bank transfer to pay the registration fee.
+    /// </summary>
+    public string BankTransferId { get; set; } = string.Empty;
+    /// <summary>
     /// If <see langword="true"/>, specific content for the registering person is shown.
     /// </summary>
     public bool IsRegisteringUser { get; set; }

--- a/League/Templates/Email/ConfirmTeamApplicationTxt.tpl
+++ b/League/Templates/Email/ConfirmTeamApplicationTxt.tpl
@@ -12,13 +12,14 @@
 {{ L "We wish you much success and good luck." ~}}
 {{ if org_ctx.Bank.ShowBankDetailsInConfirmationEmail && model.IsRegisteringUser }}
 
-    {{~ padright = [ L "Amount", L "Recipient", L "IBAN", L "BIC", L "Bank name" ] | array.map "size" | array.sort | array.last ~}}
+    {{~ padright = [ L "Amount", L "Recipient", L "IBAN", L "BIC", L "Bank name", L "Reference ID" ] | array.map "size" | array.sort | array.last ~}}
     {{~ L "Please transfer the participation fee to the following bank account:" }}
     {{~ L "Amount" | string.pad_right padright }}: {{ org_ctx.Bank.Amount }} {{ org_ctx.Bank.Currency }}
     {{~ L "Recipient" | string.pad_right padright }}: {{ org_ctx.Bank.Recipient }}
     {{~ L "IBAN" | string.pad_right padright }}: {{ org_ctx.Bank.Iban }}
     {{~ L "BIC" | string.pad_right padright }}: {{ org_ctx.Bank.Bic }}
     {{~ L "Bank name" | string.pad_right padright }}: {{org_ctx.Bank.BankName }}
+    {{~ L "Reference ID" }}: {{ model.BankTransferId }}
 
     {{~ L "Thank you." }}
 {{ end }}

--- a/League/Templates/Email/Localization/EmailResource.Designer.cs
+++ b/League/Templates/Email/Localization/EmailResource.Designer.cs
@@ -19,7 +19,7 @@ namespace League.Templates.Email.Localization {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class EmailResource {

--- a/League/Templates/Email/Localization/EmailResource.de.resx
+++ b/League/Templates/Email/Localization/EmailResource.de.resx
@@ -117,6 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Reference ID" xml:space="preserve">
+    <value>Verwendungszweck</value>
+    <comment>ConfirmTeamApplication</comment>
+  </data>
   <data name="Amount" xml:space="preserve">
     <value>Betrag</value>
     <comment>ConfirmTeamApplication</comment>

--- a/League/Templates/Email/Localization/EmailResource.resx
+++ b/League/Templates/Email/Localization/EmailResource.resx
@@ -1,101 +1,120 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
-		Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-		Version 1.3
-
-		The primary goals of this format is to allow a simple XML format 
-		that is mostly human readable. The generation and parsing of the 
-		various data types are done through the TypeConverter classes 
-		associated with the data types.
-
-		Example:
-
-		... ado.net/XML headers & schema ...
-		<resheader name="resmimetype">text/microsoft-resx</resheader>
-		<resheader name="version">1.3</resheader>
-		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-		<data name="Name1">this is my long string</data>
-		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-			[base64 mime encoded serialized .NET Framework object]
-		</data>
-		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-			[base64 mime encoded string representing a byte array form of the .NET Framework object]
-		</data>
-
-		There are any number of "resheader" rows that contain simple 
-		name/value pairs.
-
-		Each data row contains a name, and value. The row also contains a 
-		type or mimetype. Type corresponds to a .NET class that support 
-		text/value conversion through the TypeConverter architecture. 
-		Classes that don't support this are serialized and stored with the 
-		mimetype set.
-
-		The mimetype is used for serialized objects, and tells the 
-		ResXResourceReader how to depersist the object. This is currently not 
-		extensible. For a given mimetype the value must be set accordingly:
-
-		Note - application/x-microsoft.net.object.binary.base64 is the format 
-		that the ResXResourceWriter will generate, however the reader can 
-		read any of the formats listed below.
-
-		mimetype: application/x-microsoft.net.object.binary.base64
-		value   : The object must be serialized with 
-			: System.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.soap.base64
-		value   : The object must be serialized with 
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.bytearray.base64
-		value   : The object must be serialized into a byte array 
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
-	
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
 </root>


### PR DESCRIPTION
The confirmation email sent to teams registering for a tournament now contains a Reference ID for bank transfers. It contains the Tournament Id (A), Team Id (T), and User Id (U) in this format: **`A3-T45-U67`**.