### PR TITLE
Fix: Add teamId to returnUrls to return to Team.MyTeam methods

### DIFF
--- a/League/Controllers/Role.cs
+++ b/League/Controllers/Role.cs
@@ -204,7 +204,7 @@ public class Role : AbstractController
                     MessageId = isSuccess ? MyTeamMessageModel.MessageId.MemberRemoveSuccess : MyTeamMessageModel.MessageId.MemberRemoveFailure
                 });
 
-            return TenantLink.Action(nameof(Team.MyTeam), nameof(Team)) ?? string.Empty;
+            return TenantLink.Action(nameof(Team.MyTeam), nameof(Team), new { id = teamId }) ?? string.Empty;
         }
 
         return returnUrl;

--- a/League/Controllers/Team.cs
+++ b/League/Controllers/Team.cs
@@ -170,7 +170,7 @@ public class Team : AbstractController
                 Authorization.TeamOperations.EditTeam)).Succeeded)
         {
             return JsonResponseRedirect(Url.Action(nameof(Error.AccessDenied), nameof(Error),
-                new { ReturnUrl = TenantLink.Action(nameof(MyTeam), nameof(Team)) }));
+                new { ReturnUrl = TenantLink.Action(nameof(MyTeam), nameof(Team), new { id = default(long?) }) }));
         }
 
         var model = new TeamEditModel
@@ -201,7 +201,7 @@ public class Team : AbstractController
                     Authorization.TeamOperations.EditTeam)).Succeeded)
             {
                 return JsonResponseRedirect(Url.Action(nameof(Error.AccessDenied), nameof(Error),
-                    new {ReturnUrl = TenantLink.Action(nameof(MyTeam), nameof(Team))}));
+                    new {ReturnUrl = TenantLink.Action(nameof(MyTeam), nameof(Team), new { id = default(long?) }) }));
             }
 
             team.TeamInRounds.AddRange(await _appDb.TeamInRoundRepository.GetTeamInRoundAsync(
@@ -257,7 +257,7 @@ public class Team : AbstractController
         {
             TempData.Put<MyTeamMessageModel.MyTeamMessage>(nameof(MyTeamMessageModel.MyTeamMessage), new MyTeamMessageModel.MyTeamMessage { AlertType = SiteAlertTagHelper.AlertType.Danger, MessageId = MyTeamMessageModel.MessageId.TeamDataFailure});
             _logger.LogError(e, "Error saving team id '{TeamId}'", model.Team.IsNew ? "new" : model.Team.Id.ToString());
-            return JsonResponseRedirect(TenantLink.Action(nameof(MyTeam), nameof(Team),new { id = team.Id }));
+            return JsonResponseRedirect(TenantLink.Action(nameof(MyTeam), nameof(Team), new { id = team.Id }));
         }
 
         // We never should come this far
@@ -281,7 +281,7 @@ public class Team : AbstractController
     }
 
     [HttpGet("[action]/{tid}")]
-    public async Task<IActionResult> SelectVenue(long tid, string returnUrl, CancellationToken cancellationToken)
+    public async Task<IActionResult> SelectVenue(long tid, string? returnUrl, CancellationToken cancellationToken)
     {
         if (!ModelState.IsValid) return NotFound();
 
@@ -306,7 +306,7 @@ public class Team : AbstractController
                 TournamentId = _tenantContext.TournamentContext.TeamTournamentId, TeamId = teamEntity.Id, VenueId = teamEntity.VenueId,
                 ReturnUrl = (Url.IsLocalUrl(returnUrl)
                     ? returnUrl
-                    : TenantLink.Action(nameof(MyTeam), nameof(Team))) ?? string.Empty
+                    : TenantLink.Action(nameof(MyTeam), nameof(Team), new { id = teamEntity.Id })) ?? string.Empty
             }
         );
     }
@@ -318,7 +318,7 @@ public class Team : AbstractController
         // model binding is not case-sensitive
 
         if (!ModelState.IsValid) return JsonResponseRedirect(Url.Action(nameof(Error.AccessDenied), nameof(Error),
-            new { ReturnUrl = TenantLink.Action(nameof(MyTeam), nameof(Team)) }));
+            new { ReturnUrl = TenantLink.Action(nameof(MyTeam), nameof(Team), new { id = default(long?) }) }));
 
         var teamEntity = await
             _appDb.TeamRepository.GetTeamEntityAsync(new PredicateExpression(TeamFields.Id == model.TeamId),
@@ -334,7 +334,7 @@ public class Team : AbstractController
                 Authorization.TeamOperations.EditTeam)).Succeeded)
         {
             return JsonResponseRedirect(Url.Action(nameof(Error.AccessDenied), nameof(Error),
-                new { ReturnUrl = TenantLink.Action(nameof(MyTeam), nameof(Team), new { model.TeamId }) }));
+                new { ReturnUrl = TenantLink.Action(nameof(MyTeam), nameof(Team), new { id = default(long?) }) }));
         }
 
         model.TournamentId = _tenantContext.TournamentContext.TeamTournamentId;
@@ -364,7 +364,7 @@ public class Team : AbstractController
             _logger.LogError(e, "Failed to save selected venue for team id {TeamId}, venue id {VSenueId}", model.TeamId, model.VenueId);
         }
             
-        return JsonResponseRedirect(TenantLink.Action(nameof(MyTeam), nameof(Team), new { model.TeamId }));
+        return JsonResponseRedirect(TenantLink.Action(nameof(MyTeam), nameof(Team), new { id = model.TeamId }));
     }
 
     private List<long> GetUserClaimTeamIds()

--- a/League/Views/Team/_ChangeVenueModalPartial.cshtml
+++ b/League/Views/Team/_ChangeVenueModalPartial.cshtml
@@ -20,7 +20,7 @@
                        asp-controller="@nameof(Venue)"
                        asp-route-id="@Model.VenueId"
                        asp-route-tenant="@tenantUrlSegment"
-                       asp-route-returnurl="@(TenantLink.Action(nameof(Team.MyTeam), nameof(Team)))"
+                       asp-route-returnurl="@(TenantLink.Action(nameof(Team.MyTeam), nameof(Team), new {id = Model.TeamId}))"
                        site-authorize-resource site-resource="@(new List<VenueTeamRow>{{ new VenueTeamRow{ TeamId = Model.TeamId, VenueId = Model.VenueId.Value }}})"
                        site-requirement="@League.Authorization.VenueOperations.EditVenue"
                        class="btn btn-primary d-block w-100">@Localizer["Edit current venue"]</a>
@@ -36,7 +36,7 @@
                    asp-controller="@nameof(Venue)"
                    asp-route-tenant="@tenantUrlSegment"
                    asp-route-tid="@Model.TeamId"
-                   asp-route-returnurl="@TenantLink.Action(nameof(Team.MyTeam), nameof(Team))"
+                   asp-route-returnurl="@TenantLink.Action(nameof(Team.MyTeam), nameof(Team), new {id = Model.TeamId})"
                    site-authorize-resource site-resource="@(new List<VenueTeamRow>())"
                    site-requirement="@League.Authorization.VenueOperations.CreateVenue"
                    class="btn btn-primary d-block w-100">@Localizer["Create new team venue"]</a>

--- a/TournamentManager/TournamentManager.Tests/Plan/MatchSchedulerTests.cs
+++ b/TournamentManager/TournamentManager.Tests/Plan/MatchSchedulerTests.cs
@@ -19,6 +19,21 @@ internal class MatchSchedulerTests
     private readonly TournamentEntity? _tournamentEntityForMatchScheduler = ScheduleHelper.GetTournament();
 
     [Test]
+    public void RoundWithOnlyOneParticipant_ShouldThrow()
+    {
+        var participants = _tournamentEntityForMatchScheduler!.Rounds.First().TeamCollectionViaTeamInRound;
+        // Remove all but one participant
+        while (participants.Count > 1)
+        {
+            participants.RemoveAt(0);
+        }
+        var scheduler = GetMatchSchedulerInstance();
+
+        Assert.That(del: async () => await scheduler.ScheduleFixturesForTournament(false, CancellationToken.None),
+    Throws.InvalidOperationException.With.Message.EqualTo("Round-robin system requires at least 2 participants."));
+    }
+
+    [Test]
     public void Generate_Schedule_Should_Succeed()
     {
         EntityCollection<MatchEntity> matches = new(); 


### PR DESCRIPTION
- Updated `SetAdjustedReturnResult` to include `teamId` in return URL.
- Modified methods in `Team.cs` to maintain team context in redirects.
- Made `returnUrl` parameter nullable in `SelectVenue`.
- Adjusted `_ChangeVenueModalPartial.cshtml` to pass `Model.TeamId` in URLs.
- Added unit tests in `MatchSchedulerTests.cs` for single participant scenarios.
- Improved scheduling logic in `MatchScheduler.cs` for rounds with no or one team.