### PR TITLE
Fix: Reportsheet PDF output with dashed lines

### DIFF
--- a/League/Views/Match/ReportSheet.cshtml
+++ b/League/Views/Match/ReportSheet.cshtml
@@ -287,9 +287,9 @@
                     </div>
                     @for (var points = 1; points < 31; points++)
                     {
-                        <div class="row">
-                            <div class="col-6 border-right@(ballPointsToWin[i - 1] == points ? " dotted-line" : string.Empty)">@points</div>
-                            <div class="col-6 border-right@(ballPointsToWin[i - 1] == points ? " dotted-line" : string.Empty)">@points</div>
+                        <div class="row@(ballPointsToWin[i - 1] == points ? " dotted-line" : string.Empty)">
+                            <div class="col-6 border-right">@points</div>
+                            <div class="col-6 border-right">@points</div>
                         </div>
                     }
                 </div>


### PR DESCRIPTION
The dashed line marking the start of the two-point advantage rule is now rendered correctly across different browsers (HTML and PDF).