### PR TITLE
Update NuGet packages and add NuGet.Protocol

### DIFF
--- a/League/League.csproj
+++ b/League/League.csproj
@@ -67,33 +67,34 @@ Localizations for English and German are included. The library is in operation o
         <PackageReference Include="Axuno.TextTemplating" Version="3.0.0" />
         <PackageReference Include="JSNLog" Version="3.0.3" />
         <PackageReference Include="MailMergeLib" Version="5.15.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.7" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.7" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.7" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.9" />
         <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-        <PackageReference Include="NLog" Version="6.1.2" />
+        <PackageReference Include="NLog" Version="6.1.3" />
         <PackageReference Include="NLog.Targets.Trace" Version="6.0.3" />
-        <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.2" />
+        <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.3" />
+        <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
         <PackageReference Include="NuGetizer" Version="1.4.7">
             <PrivateAssets>all</PrivateAssets>
             <PackEmbeddedResource>true</PackEmbeddedResource>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="StackifyMiddleware" Version="3.3.3.4767" />
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
     </ItemGroup>
     <ItemGroup>
         <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.3" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.203">
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>


### PR DESCRIPTION
Upgraded various NuGet dependencies to latest versions, including
* Microsoft.AspNetCore.Authentication.*
* NLog,
* NLog.Web.AspNetCore,
* Microsoft.SourceLink.GitHub,
* System.Security.Cryptography.Xml,
* Microsoft.CodeAnalysis.NetAnalyzers.

Added NuGet.Protocol 7.6.0 package reference.