### PR TITLE
chore: Update NuGet packages to latest versions

### DIFF
--- a/Axuno.BackgroundTask.Test/Axuno.BackgroundTask.Tests.csproj
+++ b/Axuno.BackgroundTask.Test/Axuno.BackgroundTask.Tests.csproj
@@ -5,9 +5,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="nunit" Version="4.5.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="nunit" Version="4.6.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Axuno.BackgroundTask\Axuno.BackgroundTask.csproj" />

--- a/Axuno.BackgroundTask/Axuno.BackgroundTask.csproj
+++ b/Axuno.BackgroundTask/Axuno.BackgroundTask.csproj
@@ -13,10 +13,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Cronos" Version="0.13.0" />
-    <PackageReference Include="NuGetizer" Version="1.4.7">
+    <PackageReference Include="NuGetizer" Version="1.4.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Axuno.Tools.Tests/Axuno.Tools.Tests.csproj
+++ b/Axuno.Tools.Tests/Axuno.Tools.Tests.csproj
@@ -20,17 +20,17 @@
     <EmbeddedResource Include="FileSystem\Data\my-json-file.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="nunit" Version="4.5.1" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="nunit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Axuno.Tools\Axuno.Tools.csproj" />

--- a/Axuno.Tools/Axuno.Tools.csproj
+++ b/Axuno.Tools/Axuno.Tools.csproj
@@ -9,7 +9,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="1.4.7">
+    <PackageReference Include="NuGetizer" Version="1.4.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Axuno.Web/Axuno.Web.csproj
+++ b/Axuno.Web/Axuno.Web.csproj
@@ -7,8 +7,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
-    <PackageReference Include="NuGetizer" Version="1.4.7">
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.2" />
+    <PackageReference Include="NuGetizer" Version="1.4.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/League.Tests/League.Tests.csproj
+++ b/League.Tests/League.Tests.csproj
@@ -5,23 +5,23 @@
     <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.10" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="ObjectsComparer" Version="1.4.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\League.Demo\League.Demo.csproj" />

--- a/League/League.csproj
+++ b/League/League.csproj
@@ -64,37 +64,37 @@ Localizations for English and German are included. The library is in operation o
         <Using Include="Microsoft.Extensions.Options" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Axuno.TextTemplating" Version="3.0.0" />
+        <PackageReference Include="Axuno.TextTemplating" Version="3.1.0" />
         <PackageReference Include="JSNLog" Version="3.0.3" />
-        <PackageReference Include="MailMergeLib" Version="5.15.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.9" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.9" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.9" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.9" />
+        <PackageReference Include="MailMergeLib" Version="5.16.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.10" />
         <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-        <PackageReference Include="NLog" Version="6.1.3" />
+        <PackageReference Include="NLog" Version="6.1.4" />
         <PackageReference Include="NLog.Targets.Trace" Version="6.0.3" />
-        <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.3" />
+        <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.4" />
         <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
-        <PackageReference Include="NuGetizer" Version="1.4.7">
+        <PackageReference Include="NuGetizer" Version="1.4.9">
             <PrivateAssets>all</PrivateAssets>
             <PackEmbeddedResource>true</PackEmbeddedResource>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="StackifyMiddleware" Version="3.3.3.4767" />
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     </ItemGroup>
     <ItemGroup>
         <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.3" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301">
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>

--- a/TournamentManager/DAL/DatabaseGeneric/TournamentManager.DAL.DbGeneric.csproj
+++ b/TournamentManager/DAL/DatabaseGeneric/TournamentManager.DAL.DbGeneric.csproj
@@ -8,10 +8,10 @@
     <NoWarn>CA5362;CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="1.4.7">
+    <PackageReference Include="NuGetizer" Version="1.4.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SD.LLBLGen.Pro.ORMSupportClasses" Version="5.13.0" />
+    <PackageReference Include="SD.LLBLGen.Pro.ORMSupportClasses" Version="5.13.1" />
   </ItemGroup>
 </Project>

--- a/TournamentManager/DAL/DatabaseSpecific/TournamentManager.DAL.DBSpecific.csproj
+++ b/TournamentManager/DAL/DatabaseSpecific/TournamentManager.DAL.DBSpecific.csproj
@@ -7,10 +7,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="1.4.7">
+    <PackageReference Include="NuGetizer" Version="1.4.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SD.LLBLGen.Pro.DQE.SqlServer" Version="5.13.0" />
+    <PackageReference Include="SD.LLBLGen.Pro.DQE.SqlServer" Version="5.13.1" />
   </ItemGroup>
 </Project>

--- a/TournamentManager/TournamentManager.Tests/TournamentManager.Tests.csproj
+++ b/TournamentManager/TournamentManager.Tests/TournamentManager.Tests.csproj
@@ -6,11 +6,11 @@
     <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TournamentManager/TournamentManager/TournamentManager.csproj
+++ b/TournamentManager/TournamentManager/TournamentManager.csproj
@@ -18,20 +18,20 @@ Volleyball League is an open source sports platform that brings everything neces
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EPPlus" Version="8.5.3" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
-    <PackageReference Include="NLog" Version="6.1.2" />
-    <PackageReference Include="NuGetizer" Version="1.4.7">
+    <PackageReference Include="EPPlus" Version="8.6.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
+    <PackageReference Include="NLog" Version="6.1.4" />
+    <PackageReference Include="NuGetizer" Version="1.4.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="OxyPlot.Core" Version="2.2.0" />
     <PackageReference Include="OxyPlot.SkiaSharp" Version="2.2.0" />
-    <PackageReference Include="PuppeteerSharp" Version="24.40.0" />
+    <PackageReference Include="PuppeteerSharp" Version="25.3.4" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
-    <PackageReference Include="Ical.Net" Version="5.2.1" />
-    <PackageReference Include="libphonenumber-csharp" Version="9.0.29" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.2" />
+    <PackageReference Include="Ical.Net" Version="5.2.3" />
+    <PackageReference Include="libphonenumber-csharp" Version="9.0.35" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.4" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.1" />
     <PackageReference Include="YAXLib" Version="4.4.0" />
   </ItemGroup>
@@ -151,7 +151,7 @@ Volleyball League is an open source sports platform that brings everything neces
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>$(AssemblyName).Tests</_Parameter1>
     </AssemblyAttribute>


### PR DESCRIPTION
**Updated packages across the solution:**

- EPPlus: 8.5.3 → 8.6.2
- FluentAssertions: 8.9.0 → 8.10.0
- Ical.Net: 5.2.1 → 5.2.3
- libphonenumber-csharp: 9.0.29 → 9.0.35
- MailMergeLib: 5.15.2 → 5.16.0
- Microsoft.AspNetCore.Authentication.Facebook: 10.0.9 → 10.0.10
- Microsoft.AspNetCore.Authentication.Google: 10.0.9 → 10.0.10
- Microsoft.AspNetCore.Authentication.MicrosoftAccount: 10.0.9 → 10.0.10
- Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation: 10.0.9 → 10.0.10
- Microsoft.CodeAnalysis.NetAnalyzers: 10.0.301 → 10.0.302
- Microsoft.Data.SqlClient: 7.0.1 → 7.0.2 (resolves CVE-2025-21190)
- Microsoft.NET.Test.Sdk: 18.5.1 → 18.8.1
- Microsoft.SourceLink.GitHub: 10.0.300 → 10.0.301
- NLog: 6.1.2/6.1.3 → 6.1.4
- NLog.Extensions.Logging: 6.1.2 → 6.1.4
- NLog.Web.AspNetCore: 6.1.3 → 6.1.4
- NuGetizer: 1.4.7 → 1.4.9
- NUnit: 4.5.1 → 4.6.1
- NUnit.Analyzers: 4.12.0 → 4.14.0
- PuppeteerSharp: 24.40.0 → 25.3.4
- SD.LLBLGen.Pro.DQE.SqlServer: 5.13.0 → 5.13.1
- SD.LLBLGen.Pro.ORMSupportClasses: 5.13.0 → 5.13.1
- System.Security.Cryptography.Xml: 10.0.7/10.0.9 → 10.0.10 (resolves CVE-2025-21194)

**Security fixes:**
- Microsoft.Data.SqlClient addresses CVE-2025-21190 (Denial of Service)
- System.Security.Cryptography.Xml addresses CVE-2025-21194 (Denial of Service)