### PR TITLE
feat: Add JSONC serializer for JSON with comments

### DIFF
--- a/TournamentManager/TournamentManager.Tests/JsonCSerializer/JsonCSerializerTests.cs
+++ b/TournamentManager/TournamentManager.Tests/JsonCSerializer/JsonCSerializerTests.cs
@@ -1,0 +1,383 @@
+using System.Text.Json.Serialization;
+using NUnit.Framework;
+using TournamentManager.JsonCSerializer;
+
+namespace TournamentManager.Tests.JsonCSerializer;
+
+[TestFixture]
+public class JsonCSerializerTests
+{
+    [JsonComment("A sample person object for testing")]
+    private class Person
+    {
+        [JsonComment("The person's full name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonComment("The person's age in years")]
+        public int Age { get; set; }
+
+        [JsonComment("Whether the person is active")]
+        public bool IsActive { get; set; }
+    }
+
+    [JsonComment(
+        """
+        A test class with multiline comment
+        using raw string literals
+        """)]
+    private class MultilineCommentClass
+    {
+        [JsonComment(
+            """
+            This is a multiline property comment
+            that spans multiple lines
+            """)]
+        public string TestProperty { get; set; } = "test value";
+
+        [JsonComment("Single line comment")]
+        public int Number { get; set; } = 42;
+    }
+
+    [JsonComment("Class with a dictionary property")]
+    private class ClassContainingDictionary
+    {
+        [JsonComment("This is a dictionary comment")]
+        public Dictionary<int, string> TestDictionary { get; set; } = new()
+        {
+            { 1, "One" },
+            { 2, "Two" },
+            { 3, "Three" }
+        };
+
+        [JsonComment("Just a number")]
+        public int Number { get; set; } = 42;
+    }
+
+    [JsonComment("Class with custom class / property name")]
+    [JsonTypeName("CustomConfig")]
+    private class ConfigWithCustomName
+    {
+        [JsonComment("Setting value")]
+        [JsonPropertyName("Config")]
+        public string Setting { get; set; } = "default";
+
+        public object? NullValue { get; set; } = null;
+    }
+
+    private class TestClassWithList
+    {
+        public List<int> Numbers { get; set; } = [];
+    }
+
+    [Test]
+    public void Serialize_WithoutRootAsNamedProperty_OutputsObjectDirectly()
+    {
+        // Arrange
+        var person = new Person
+        {
+            Name = "John Doe",
+            Age = 30,
+            IsActive = true
+        };
+
+        var options = new JsonCSerializerOptions
+        {
+            WriteRootComment = true,
+            WriteRootAsNamedProperty = false
+        };
+
+        // Act
+        var result = JsonCSerializer<Person>.Serialize(person, options);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Does.Contain("// A sample person object for testing"));
+            Assert.That(result, Does.Contain("\"Name\": \"John Doe\""));
+            Assert.That(result, Does.Contain("\"Age\": 30"));
+            Assert.That(result, Does.StartWith("// A sample person")); // Comment at the start
+
+            // Should NOT be wrapped in an outer object
+            var lines = result.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            var firstJsonLine = lines.FirstOrDefault(l => !l.TrimStart().StartsWith("//"));
+            Assert.That(firstJsonLine, Does.StartWith("{")); // Direct object
+        }
+    }
+
+    [Test]
+    public void Serialize_WithRootAsNamedProperty_OutputsWrappedObject()
+    {
+        // Arrange
+        var person = new Person
+        {
+            Name = "Jane Smith",
+            Age = 25,
+            IsActive = false
+        };
+
+        var options = new JsonCSerializerOptions
+        {
+            WriteRootComment = true,
+            WriteRootAsNamedProperty = true
+        };
+
+        // Act
+        var result = JsonCSerializer<Person>.Serialize(person, options);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Does.Contain("// A sample person object for testing"));
+            Assert.That(result, Does.Contain("\"Person\":"));
+            Assert.That(result, Does.Contain("\"Name\": \"Jane Smith\""));
+            Assert.That(result, Does.Contain("\"Age\": 25"));
+
+            // Should be wrapped in an outer object
+            var lines = result.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            Assert.That(lines[0].Trim(), Is.EqualTo("{")); // Outer opening brace
+            Assert.That(result, Does.Match(@"\{\s+//.*\s+""Person"":\s+\{")); // Outer object with Person property
+        }
+    }
+
+    [Test]
+    public void Serialize_WithRootAsNamedProperty_NoComment_OutputsWrappedObjectWithoutComment()
+    {
+        // Arrange
+        var person = new Person
+        {
+            Name = "Bob Johnson",
+            Age = 40,
+            IsActive = true
+        };
+
+        var options = new JsonCSerializerOptions
+        {
+            WriteRootComment = false,
+            WriteRootAsNamedProperty = true
+        };
+
+        // Act
+        var result1 = JsonCSerializer<Person>.Serialize(person, options);
+        options.RespectJsonPropertyOrder = false; // default is true
+        var result2 = JsonCSerializer<Person>.Serialize(person, options);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result1, Is.EquivalentTo(result2)); // no ordering present
+            Assert.That(result1, Does.Contain("\"Person\":"));
+            Assert.That(result1, Does.Contain("\"Name\": \"Bob Johnson\""));
+            Assert.That(result1, Does.Not.Contain("// A sample person object for testing"));
+
+            var lines = result1.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            Assert.That(lines[0].Trim(), Is.EqualTo("{")); // Outer opening brace
+            Assert.That(lines[1].Trim(), Does.StartWith("\"Person\":")); // Person property without comment
+        }
+    }
+
+    [Test]
+    public void Serialize_WithMultilineRawStringComments_OutputsMultilineComments()
+    {
+        // Arrange
+        var obj = new MultilineCommentClass
+        {
+            TestProperty = "test value",
+            Number = 42
+        };
+
+        var options = new JsonCSerializerOptions
+        {
+            Indent = "  ",
+            WriteRootComment = true
+        };
+
+        // Act
+        var result = JsonCSerializer<MultilineCommentClass>.Serialize(obj, options);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Does.Contain("// A test class with multiline comment"));
+            Assert.That(result, Does.Contain("// using raw string literals"));
+            Assert.That(result, Does.Contain("// This is a multiline property comment"));
+            Assert.That(result, Does.Contain("// that spans multiple lines"));
+            Assert.That(result, Does.Contain("// Single line comment"));
+            Assert.That(result, Does.Contain("\"TestProperty\": \"test value\""));
+            Assert.That(result, Does.Contain("\"Number\": 42"));
+        }
+    }
+
+    [Test]
+    public void DictionarySerialization()
+    {
+        var obj = new ClassContainingDictionary();
+        var options = new JsonCSerializerOptions
+        {
+            Indent = "  ",
+            WriteRootComment = true
+        };
+
+        // Act
+        var result = JsonCSerializer<ClassContainingDictionary>.Serialize(obj, options);
+        var deserialized = JsonCSerializer<ClassContainingDictionary>.Deserialize(result);
+        var deserializedSectionExplicit = JsonCSerializer<ClassContainingDictionary>.Deserialize<ClassContainingDictionary>(result);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Does.Contain("// Class with a dictionary property"));
+            Assert.That(result, Does.Contain("// This is a dictionary comment"));
+            Assert.That(result, Does.Contain("\"TestDictionary\":"));
+            Assert.That(result, Does.Contain("\"1\": \"One\""));
+            Assert.That(result, Does.Contain("\"2\": \"Two\""));
+            Assert.That(result, Does.Contain("\"3\": \"Three\""));
+            Assert.That(deserialized.TestDictionary, Is.EquivalentTo(obj.TestDictionary));
+            Assert.That(deserializedSectionExplicit.TestDictionary, Is.EquivalentTo(obj.TestDictionary));
+        }
+    }
+
+    [Test]
+    public void Deserialize_WithMultiplePropertiesAtRoot_UsesRootElement()
+    {
+        // Arrange
+        // JSON with multiple properties at root
+        // (doesn't match auto-unwrap criteria)
+        var json = """
+        {
+            "Name": "Alice",
+            "Age": 35,
+            "IsActive": true
+        }
+        """;
+
+        // Act
+        var result = JsonCSerializer<Person>.Deserialize(json);
+
+        // Assert
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Name, Is.EqualTo("Alice"));
+            Assert.That(result.Age, Is.EqualTo(35));
+            Assert.That(result.IsActive, Is.True);
+        }
+    }
+
+    [Test]
+    public void Deserialize_WithSinglePropertyNotMatchingTypeName_UsesRootElement()
+    {
+        // Arrange
+        // JSON with single property at root but name doesn't match type name
+        var json = """
+                   {
+                       "Data": {
+                           "Name": "Bob",
+                           "Age": 42,
+                           "IsActive": false
+                       }
+                   }
+                   """;
+
+        // Act & Assert - Should throw because the root object has unmapped "Data" property
+        Assert.Throws<System.Text.Json.JsonException>(() =>
+            JsonCSerializer<Person>.Deserialize(json));
+    }
+
+    [Test]
+    public void Deserialize_WithNonObjectRoot_UsesRootElement()
+    {
+        // Arrange - JSON with array at root (not an object)
+        var jsonArray = """
+        [
+            { "Name": "Charlie", "Age": 28, "IsActive": true }
+        ]
+        """;
+
+        // Act & Assert - Should fail since root is array, not object
+        Assert.Throws<System.Text.Json.JsonException>(() =>
+            JsonCSerializer<Person>.Deserialize(jsonArray));
+    }
+
+    [Test]
+    public void Deserialize_WithPrimitiveRoot_UsesRootElement()
+    {
+        // Arrange - JSON with primitive at root (string)
+        var jsonString = "\"Simple string value\"";
+
+        // Act
+        var result = JsonCSerializer<string>.Deserialize(jsonString);
+
+        // Assert
+        Assert.That(result, Is.EqualTo("Simple string value"));
+    }
+
+    [Test]
+    public void Deserialize_WithNumberRoot_UsesRootElement()
+    {
+        // Arrange - JSON with number at root
+        var jsonNumber = "42";
+
+        // Act
+        var result = JsonCSerializer<int>.Deserialize(jsonNumber);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void Serialize_WithJsonPropertyNameAttribute_UsesCustomPropertyName()
+    {
+        // Arrange - Tests GetRootPropertyName when JsonPropertyNameAttribute is not null
+        var config = new ConfigWithCustomName
+        {
+            Setting = "production",
+            NullValue = null
+        };
+
+        var options = new JsonCSerializerOptions
+        {
+            WriteRootComment = true,
+            WriteRootAsNamedProperty = true
+        };
+
+        // Act
+        var result = JsonCSerializer<ConfigWithCustomName>.Serialize(config, options);
+        /*
+          {
+             // Class with custom class / property name
+             "CustomConfig": {
+               // Setting value
+               "Config": "production",
+               "NullValue": null
+             }
+           }
+         */
+
+        // Assert - Should use
+        // 1. "CustomConfig" from class attribute instead of "ConfigWithCustomName"
+        // 2. "Config" from attribute instead of "Setting"
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Does.Contain("// Class with custom class / property name"));
+            Assert.That(result, Does.Contain("// Setting value"));
+            Assert.That(result, Does.Contain("\"CustomConfig\": {"));
+            Assert.That(result, Does.Contain("\"Config\": \"production\""));
+            Assert.That(result, Does.Contain("\"NullValue\": null"));
+        }
+    }
+
+    [Test]
+    public void Serialize_WithListOfIntegers_WritesJsonArray()
+    {
+        // Arrange
+        var testData = new TestClassWithList
+        {
+            Numbers = [1, 2, 3]
+        };
+
+        // Act
+        var result = JsonCSerializer<TestClassWithList>.Serialize(testData);
+
+        // Assert
+        Assert.That(result, Does.Contain("\"Numbers\": ["));
+        Assert.That(result, Does.Contain("1,"));
+        Assert.That(result, Does.Contain("2,"));
+        Assert.That(result, Does.Contain("3"));
+        Assert.That(result, Does.Contain("]"));
+    }
+}

--- a/TournamentManager/TournamentManager/JsonCSerializer/JsonCSerializer.cs
+++ b/TournamentManager/TournamentManager/JsonCSerializer/JsonCSerializer.cs
@@ -1,0 +1,511 @@
+﻿using System.Collections;
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace TournamentManager.JsonCSerializer;
+
+/// <summary>
+/// Writes configuration objects as JSONC, i.e. JSON with // comments.
+/// Comments are created from <see cref="JsonCommentAttribute"/>.
+/// <para/>
+/// For deserialization, comments are ignored
+/// and the JSON is parsed by <see cref="JsonSerializer"/>.
+/// </summary>
+public static class JsonCSerializer<T>
+{
+    /// <summary>
+    /// Serializes the given value to a JSONC string.
+    /// </summary>
+    /// <param name="value">The value to serialize.</param>
+    /// <param name="options">The serialization options.</param>
+    /// <returns>The JSONC string representation of the value.</returns>
+    public static string Serialize(
+        T value,
+        JsonCSerializerOptions? options = null)
+    {
+        options ??= new JsonCSerializerOptions();
+        var context = new WriterContext(options);
+        
+        if (options.WriteRootAsNamedProperty)
+        {
+            WriteWrappedRoot(context, value, typeof(T), options);
+        }
+        else
+        {
+            WriteDirectRoot(context, value, typeof(T), options);
+        }
+
+        return context.ToString();
+    }
+
+    /// <summary>
+    /// Deserializes a JSON or JSONC string into an object of type T.
+    /// </summary>
+    /// <param name="jsonC">The JSONC string to deserialize.</param>
+    /// <param name="sectionName">The optional section name to deserialize.</param>
+    /// <param name="options">The deserialization options.</param>
+    /// <returns>The deserialized object of type T.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if deserialization fails.</exception>
+    public static T Deserialize(
+        string jsonC,
+        string? sectionName = null,
+        JsonCSerializerOptions? options = null)
+    {
+        options ??= new JsonCSerializerOptions();
+
+        using var document = JsonDocument.Parse(
+            jsonC,
+            new JsonDocumentOptions
+            {
+                CommentHandling = JsonCommentHandling.Skip
+            });
+
+        JsonElement section;
+
+        if (sectionName is not null)
+        {
+            section = document.RootElement.GetProperty(sectionName);
+        }
+        else
+        {
+            // Auto-detect: if root has single property matching type name, unwrap it
+            if (document.RootElement.ValueKind == JsonValueKind.Object)
+            {
+                var properties = document.RootElement.EnumerateObject().ToList();
+                if (properties.Count == 1 && properties[0].Name == typeof(T).Name)
+                {
+                    section = properties[0].Value;
+                }
+                else
+                {
+                    section = document.RootElement;
+                }
+            }
+            else
+            {
+                section = document.RootElement;
+            }
+        }
+
+        return section.Deserialize<T>(options.SerializerOptions)
+               ?? throw new InvalidOperationException("Failed to deserialize input string");
+    }
+
+    /// <summary>
+    /// Deserializes a JSONC string using the root type name as the section name.
+    /// </summary>
+    /// <param name="jsonC">The JSONC string to deserialize.</param>
+    /// <param name="options">The deserialization options.</param>
+    /// <returns>The deserialized object of type T.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if deserialization fails.</exception>
+    public static T Deserialize<TSection>(
+        string jsonC,
+        JsonCSerializerOptions? options = null)
+        where TSection : class
+    {
+        return Deserialize(jsonC, typeof(TSection).Name, options);
+    }
+
+    /// <summary>
+    /// Writes the root value wrapped in an outer object with a property name.
+    /// </summary>
+    private static void WriteWrappedRoot(
+        WriterContext context,
+        T value,
+        Type type,
+        JsonCSerializerOptions options)
+    {
+        context.WriteRaw("{" + options.NewLine);
+
+        if (options.WriteRootComment && type.GetCustomAttribute<JsonCommentAttribute>() is { } comment)
+        {
+            context.WriteComment(comment.Text, 1);
+        }
+
+        context.WriteIndent(1);
+        context.WriteJsonString(GetRootPropertyName(type));
+        context.WriteRaw(": ");
+        context.WriteValue(value, type, 1);
+        context.WriteRaw(options.NewLine + "}");
+    }
+
+    /// <summary>
+    /// Writes the root value directly without wrapping.
+    /// </summary>
+    private static void WriteDirectRoot(
+        WriterContext context,
+        T value,
+        Type type,
+        JsonCSerializerOptions options)
+    {
+        if (options.WriteRootComment && type.GetCustomAttribute<JsonCommentAttribute>() is { } comment)
+        {
+            context.WriteComment(comment.Text, 0);
+        }
+
+        context.WriteValue(value, type, 0);
+    }
+
+    private static string GetRootPropertyName(Type type)
+    {
+        // Use JsonTypeNameAttribute if present
+        var jsonTypeName = type.GetCustomAttribute<JsonTypeNameAttribute>();
+        return jsonTypeName is not null ? jsonTypeName.Name : type.Name;
+    }
+
+    /// <summary>
+    /// Class for writing JSONC with comments and indentation.
+    /// </summary>
+    private sealed class WriterContext(JsonCSerializerOptions options)
+    {
+        private readonly StringBuilder _sb = new();
+        private readonly JsonSerializerOptions _jsonOptions = options.SerializerOptions;
+
+        private readonly HashSet<object> _visited =
+            new(System.Collections.Generic.ReferenceEqualityComparer.Instance);
+
+        public override string ToString()
+        {
+            return _sb.ToString();
+        }
+
+        public void WriteRaw(string text)
+        {
+            _sb.Append(text);
+        }
+
+        public void WriteValue(object? value, Type declaredType, int level)
+        {
+            if (value is null)
+            {
+                _sb.Append("null");
+                return;
+            }
+
+            // Check for collections first (before delegating to JsonSerializer)
+            if (IsDictionary(value))
+            {
+                WriteDictionary(value, level);
+                return;
+            }
+
+            if (value is IEnumerable enumerable and not string)
+            {
+                WriteArray(enumerable, level);
+                return;
+            }
+
+            // Check if it's a complex object that needs custom serialization
+            var actualType = value.GetType();
+            if (!IsComplexObject(actualType))
+            {
+                // Let JsonSerializer handle all simple values (primitives, strings, DateTime, etc.)
+                _sb.Append(JsonSerializer.Serialize(value, declaredType, _jsonOptions));
+                return;
+            }
+
+            WriteObject(value, actualType, level);
+        }
+
+        /// <summary>
+        /// Determines if a type is a complex object requiring custom serialization.
+        /// </summary>
+        private static bool IsComplexObject(Type type)
+        {
+            type = Nullable.GetUnderlyingType(type) ?? type;
+
+            // Simple types that JsonSerializer handles well
+            if (type.IsPrimitive || type.IsEnum || type == typeof(string) ||
+                type == typeof(decimal) || type == typeof(Guid) ||
+                type == typeof(DateTime) || type == typeof(DateTimeOffset) ||
+                type == typeof(TimeSpan) || type == typeof(DateOnly) || type == typeof(TimeOnly))
+            {
+                return false;
+            }
+
+            // Everything else is a complex object
+            return true;
+        }
+
+        private void WriteObject(object value, Type type, int level)
+        {
+            CheckForCycle(value);
+
+            _sb.Append('{');
+            _sb.Append(options.NewLine);
+
+            var properties = GetWritableProperties(type)
+                .Select(p => new PropertyWriteInfo(
+                    Property: p,
+                    JsonName: GetJsonPropertyName(p),
+                    Comment: p.GetCustomAttribute<JsonCommentAttribute>()?.Text,
+                    Value: p.GetValue(value)))
+                .Where(x => options.WriteNullValues || x.Value is not null)
+                .ToList();
+
+            for (var i = 0; i < properties.Count; i++)
+            {
+                var item = properties[i];
+
+                if (!string.IsNullOrWhiteSpace(item.Comment))
+                {
+                    WriteComment(item.Comment, level + 1);
+                }
+
+                WriteIndent(level + 1);
+                WriteJsonString(item.JsonName);
+                _sb.Append(": ");
+
+                WriteValue(
+                    item.Value,
+                    item.Property.PropertyType,
+                    level + 1);
+
+                if (i < properties.Count - 1)
+                {
+                    _sb.Append(',');
+                }
+
+                _sb.Append(options.NewLine);
+            }
+
+            WriteIndent(level);
+            _sb.Append('}');
+
+            _visited.Remove(value);
+        }
+
+        private void WriteArray(IEnumerable enumerable, int level)
+        {
+            CheckForCycle(enumerable);
+
+            var items = enumerable.Cast<object?>().ToList();
+
+            _sb.Append('[');
+
+            if (items.Count > 0)
+            {
+                _sb.Append(options.NewLine);
+
+                for (var i = 0; i < items.Count; i++)
+                {
+                    WriteIndent(level + 1);
+
+                    var item = items[i];
+                    WriteValue(item, item?.GetType() ?? typeof(object), level + 1);
+
+                    if (i < items.Count - 1)
+                    {
+                        _sb.Append(',');
+                    }
+
+                    _sb.Append(options.NewLine);
+                }
+
+                WriteIndent(level);
+            }
+
+            _sb.Append(']');
+
+            _visited.Remove(enumerable);
+        }
+
+        private void WriteDictionary(object dictionary, int level)
+        {
+            CheckForCycle(dictionary);
+
+            var entries = GetDictionaryEntries(dictionary).ToList();
+
+            _sb.Append('{');
+
+            if (entries.Count > 0)
+            {
+                _sb.Append(options.NewLine);
+
+                for (var i = 0; i < entries.Count; i++)
+                {
+                    var entry = entries[i];
+
+                    WriteIndent(level + 1);
+
+                    WriteJsonString(Convert.ToString(entry.Key, CultureInfo.InvariantCulture) ?? "");
+                    _sb.Append(": ");
+
+                    WriteValue(
+                        entry.Value,
+                        entry.Value?.GetType() ?? typeof(object),
+                        level + 1);
+
+                    if (i < entries.Count - 1)
+                    {
+                        _sb.Append(',');
+                    }
+
+                    _sb.Append(options.NewLine);
+                }
+
+                WriteIndent(level);
+            }
+
+            _sb.Append('}');
+
+            _visited.Remove(dictionary);
+        }
+
+        public void WriteComment(string comment, int level)
+        {
+            foreach (var line in comment.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+            {
+                WriteIndent(level);
+                _sb.Append("// ").Append(line.Trim()).Append(options.NewLine);
+            }
+        }
+
+        public void WriteIndent(int level)
+        {
+            for (var i = 0; i < level; i++)
+            {
+                _sb.Append(options.Indent);
+            }
+        }
+
+        public void WriteJsonString(string value)
+        {
+            _sb.Append(JsonSerializer.Serialize(value, _jsonOptions));
+        }
+
+        private IReadOnlyList<PropertyInfo> GetWritableProperties(Type type)
+        {
+            var query = type
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Where(p => p.GetMethod is not null)
+                .Where(p => p.GetIndexParameters().Length == 0);
+
+            if (options.RespectJsonIgnore)
+            {
+                query = query.Where(p =>
+                {
+                    var ignore = p.GetCustomAttribute<JsonIgnoreAttribute>();
+
+                    if (ignore is null)
+                    {
+                        return true;
+                    }
+
+                    return ignore.Condition != JsonIgnoreCondition.Always;
+                });
+            }
+
+            if (options.RespectJsonPropertyOrder)
+            {
+                query = query
+                    .OrderBy(p => p.GetCustomAttribute<JsonPropertyOrderAttribute>()?.Order ?? 0)
+                    .ThenBy(p => p.MetadataToken);
+            }
+            else
+            {
+                // Properties in declaration order
+                query = query.OrderBy(p => p.MetadataToken);
+            }
+
+            return query.ToList();
+        }
+
+        private string GetJsonPropertyName(PropertyInfo property)
+        {
+            if (!options.RespectJsonPropertyName) return property.Name;
+
+            var jsonName = property.GetCustomAttribute<JsonPropertyNameAttribute>();
+
+            if (jsonName is not null)
+            {
+                return jsonName.Name;
+            }
+
+            return property.Name;
+        }
+
+        private static bool IsDictionary(object value)
+        {
+            if (value is IDictionary)
+            {
+                return true;
+            }
+
+            var type = value.GetType();
+
+            return type
+                .GetInterfaces()
+                .Any(i =>
+                    i.IsGenericType
+                    && (
+                        i.GetGenericTypeDefinition() == typeof(IDictionary<,>)
+                        || i.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>)
+                    ));
+        }
+
+        private static IEnumerable<DictionaryEntryInfo> GetDictionaryEntries(object dictionary)
+        {
+            if (dictionary is IDictionary nonGenericDictionary)
+            {
+                foreach (DictionaryEntry entry in nonGenericDictionary)
+                {
+                    yield return new DictionaryEntryInfo(entry.Key, entry.Value);
+                }
+
+                yield break;
+            }
+
+            foreach (var item in (IEnumerable) dictionary)
+            {
+                var itemType = item.GetType();
+
+                var keyProperty = itemType.GetProperty("Key");
+                var valueProperty = itemType.GetProperty("Value");
+
+                if (keyProperty is null || valueProperty is null)
+                {
+                    continue;
+                }
+
+                yield return new DictionaryEntryInfo(
+                    keyProperty.GetValue(item)!, //NOSONAR
+                    valueProperty.GetValue(item));
+            }
+        }
+
+        private void CheckForCycle(object value)
+        {
+            if (value is string)
+            {
+                return;
+            }
+
+            var type = value.GetType();
+
+            if (type.IsValueType)
+            {
+                return;
+            }
+
+            if (!_visited.Add(value))
+            {
+                throw new InvalidOperationException(
+                    $"Circular reference detected while writing JSONC. Type: {type.FullName}");
+            }
+        }
+
+        private sealed record PropertyWriteInfo(
+            PropertyInfo Property,
+            string JsonName,
+            string? Comment,
+            object? Value);
+
+        private sealed record DictionaryEntryInfo(
+            object Key,
+            object? Value);
+    }
+}

--- a/TournamentManager/TournamentManager/JsonCSerializer/JsonCSerializerOptions.cs
+++ b/TournamentManager/TournamentManager/JsonCSerializer/JsonCSerializerOptions.cs
@@ -1,0 +1,73 @@
+﻿using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace TournamentManager.JsonCSerializer;
+
+/// <summary>
+/// Options for JsonCSerializer.
+/// </summary>
+public sealed class JsonCSerializerOptions
+{
+    /// <summary>
+    /// Indentation string. Default: two spaces.
+    /// </summary>
+    public string Indent { get; set; } = "  ";
+
+    /// <summary>
+    /// Line break used for output. Default: Environment.NewLine.
+    /// </summary>
+    public string NewLine { get; set; } = Environment.NewLine;
+
+    /// <summary>
+    /// If false, properties with null values are omitted.
+    /// </summary>
+    public bool WriteNullValues { get; set; } = true;
+
+    /// <summary>
+    /// If true, enum values are written as strings. Recommended for configuration files.
+    /// </summary>
+    public bool WriteEnumsAsStrings { get; set; } = true;
+
+    /// <summary>
+    /// If true, JsonPropertyNameAttribute is respected.
+    /// </summary>
+    public bool RespectJsonPropertyName { get; set; } = true;
+
+    /// <summary>
+    /// If true, JsonPropertyOrderAttribute is respected.
+    /// </summary>
+    public bool RespectJsonPropertyOrder { get; set; } = true;
+
+    /// <summary>
+    /// If true, properties marked with JsonIgnoreAttribute are skipped.
+    /// </summary>
+    public bool RespectJsonIgnore { get; set; } = true;
+
+    /// <summary>
+    /// If true, comments attached to the root type are written before the root object.
+    /// </summary>
+    public bool WriteRootComment { get; set; } = true;
+
+    /// <summary>
+    /// If true, the root object will be wrapped in a JSON object with the type name as the property.
+    /// If false, only the root object's contents are serialized.
+    /// </summary>
+    public bool WriteRootAsNamedProperty { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the <see cref="JsonSerializerOptions"/> used for serialization and deserialization.
+    /// </summary>
+    public JsonSerializerOptions SerializerOptions { get; set; } = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+        Converters =
+        {
+            // null for naming policy with default to PascalCase
+            new JsonStringEnumConverter(null, allowIntegerValues: true)
+        }
+    };
+}

--- a/TournamentManager/TournamentManager/JsonCSerializer/JsonCommentAttribute.cs
+++ b/TournamentManager/TournamentManager/JsonCSerializer/JsonCommentAttribute.cs
@@ -1,0 +1,10 @@
+﻿namespace TournamentManager.JsonCSerializer;
+
+/// <summary>
+/// Adds a JSONC comment before a configuration property.
+/// </summary>
+[AttributeUsage(AttributeTargets.All)]
+public sealed class JsonCommentAttribute(string text) : Attribute
+{
+    public string Text { get; } = text;
+}

--- a/TournamentManager/TournamentManager/JsonCSerializer/JsonTypeNameAttribute.cs
+++ b/TournamentManager/TournamentManager/JsonCSerializer/JsonTypeNameAttribute.cs
@@ -1,0 +1,7 @@
+﻿namespace TournamentManager.JsonCSerializer;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface)]
+public sealed class JsonTypeNameAttribute(string name) : Attribute
+{
+    public string Name { get; } = name;
+}


### PR DESCRIPTION
* Introduced a JSONC serialization system supporting comments via a custom `[JsonComment]` attributes, configurable options, and root wrapping.
* The serializer `JsonCSerializer` uses `System.Text.Json` behnd the scenes.
* Added attributes for custom property/type names.
* Comprehensive unit tests cover serialization, deserialization, comments, and edge cases.
* Implementation uses reflection and prevents circular references.